### PR TITLE
Add KernelGen skills for MCP-driven GPU kernel generation

### DIFF
--- a/skills/kernelgen-for-flaggems/LICENSE.txt
+++ b/skills/kernelgen-for-flaggems/LICENSE.txt
@@ -1,0 +1,200 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get an
+      OpenPGP-compatible signature of your completed statement.
+
+   Copyright 2026 BAAI (Beijing Academy of Artificial Intelligence)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/kernelgen-for-flaggems/README.md
+++ b/skills/kernelgen-for-flaggems/README.md
@@ -1,0 +1,81 @@
+# kernelgen-for-flaggems: GPU Kernel Operator Generation for FlagGems
+
+[中文版](README_zh.md)
+
+## Overview
+
+`kernelgen-for-flaggems` is an AI coding skill that generates GPU kernel operators specifically for the FlagGems project via the `kernelgen-mcp` MCP service.
+
+### Problem Statement
+
+FlagGems has specific conventions for operator implementation: `pointwise_dynamic` wrappers, promotion methods, `flag_gems.utils` imports, categorized test files, and a unique operator registration system (`_FULL_CONFIG`). Generating code that follows all these conventions manually is tedious and error-prone.
+
+This skill automates the entire FlagGems-specific workflow: **environment check → MCP generation → FlagGems convention adaptation → operator registration → categorized testing → benchmarking**, spanning 9 steps with FlagGems-aware code transformation.
+
+### Usage
+
+```bash
+# Generate a FlagGems operator
+/kernelgen-for-flaggems relu
+
+# Generate with explicit function type
+/kernelgen-for-flaggems layer_norm --func-type normalization
+```
+
+| Argument | Required | Default | Description |
+|---|---|---|---|
+| `operator_name` | Yes | — | Operator name matching `torch.ops.aten` (e.g. `relu`, `silu`, `layer_norm`) |
+| `--func-type` | No | Auto-inferred | One of: `unary_pointwise`, `binary_pointwise`, `reduction`, `normalization`, `blas`, `other` |
+
+---
+
+## Generation Pipeline (9 Steps)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Step 0   Pre-flight: Environment & MCP Check            │
+│  Step 1   Understand the Operator Request                │
+│  Step 2   Check Whether Operator Already Exists          │
+│  Step 3   Research Context (flagos_wiki)                 │
+│  Step 4   Call kernelgen-mcp                             │
+│  Step 5   Adapt and Place Code (FlagGems conventions)    │
+│  Step 5.5 Pre-test Validation                            │
+│  Step 6   Run Accuracy Tests                             │
+│  Step 7   Run Performance Benchmark                      │
+│  Step 8   Summary Report                                 │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Key Features
+
+- **FlagGems-native code** — generates `pointwise_dynamic` style kernels with correct promotion methods
+- **Automatic registration** — adds to `__init__.py` and `_FULL_CONFIG` in alphabetical order
+- **Categorized test placement** — appends tests to `tests/test_<category>_ops.py` following existing patterns
+- **Three generation modes** — new operator, replace existing, or side-by-side custom variant (v2)
+- **Error recovery** — structured retry protocol with MCP re-generation and optimization
+
+---
+
+## Directory Structure
+
+```
+skills/kernelgen-for-flaggems/
+├── SKILL.md        # Skill definition (entry point)
+├── LICENSE.txt     # Apache 2.0 license
+├── README.md       # This document (English)
+└── README_zh.md    # Chinese version
+```
+
+---
+
+## Related Skills
+
+- [`kernelgen`](../kernelgen/) — General purpose version for any Python/Triton repository
+- [`kernelgen-for-vllm`](../kernelgen-for-vllm/) — Specialized for vLLM repositories
+- [`kernelgen-submit-feedback`](../kernelgen-submit-feedback/) — Submit bug reports and feedback
+
+---
+
+## License
+
+This project is licensed under the Apache 2.0 License. See [LICENSE.txt](LICENSE.txt) for details.

--- a/skills/kernelgen-for-flaggems/README_zh.md
+++ b/skills/kernelgen-for-flaggems/README_zh.md
@@ -1,0 +1,79 @@
+# kernelgen-for-flaggems：FlagGems GPU 算子生成
+
+## 概述
+
+`kernelgen-for-flaggems` 是一个 AI 编程技能，通过 `kernelgen-mcp` MCP 服务专门为 FlagGems 项目生成 GPU 算子。
+
+### 解决的问题
+
+FlagGems 项目有特定的算子实现规范：`pointwise_dynamic` 包装器、类型提升方法、`flag_gems.utils` 导入、分类的测试文件以及独特的算子注册系统（`_FULL_CONFIG`）。手动编写符合所有这些规范的代码既繁琐又容易出错。
+
+本技能自动化了 FlagGems 特定的工作流程：**环境检查 → MCP 代码生成 → FlagGems 规范适配 → 算子注册 → 分类测试 → 性能基准测试**，涵盖 9 个步骤，支持 FlagGems 感知的代码转换。
+
+### 使用方式
+
+```bash
+# 生成 FlagGems 算子
+/kernelgen-for-flaggems relu
+
+# 指定函数类型
+/kernelgen-for-flaggems layer_norm --func-type normalization
+```
+
+| 参数 | 必填 | 默认值 | 说明 |
+|---|---|---|---|
+| `operator_name` | 是 | — | 匹配 `torch.ops.aten` 的算子名称（如 `relu`、`silu`、`layer_norm`） |
+| `--func-type` | 否 | 自动推断 | 可选: `unary_pointwise`、`binary_pointwise`、`reduction`、`normalization`、`blas`、`other` |
+
+---
+
+## 生成流水线（9 步）
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  步骤 0   预检：环境与 MCP 检查                           │
+│  步骤 1   理解算子需求                                    │
+│  步骤 2   检查算子是否已存在                               │
+│  步骤 3   研究上下文（flagos_wiki）                        │
+│  步骤 4   调用 kernelgen-mcp                              │
+│  步骤 5   适配代码（FlagGems 规范）                        │
+│  步骤 5.5 测试前验证                                      │
+│  步骤 6   运行准确性测试                                   │
+│  步骤 7   运行性能基准测试                                 │
+│  步骤 8   生成报告                                        │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 核心特性
+
+- **FlagGems 原生代码** — 生成 `pointwise_dynamic` 风格的算子，包含正确的类型提升方法
+- **自动注册** — 按字母顺序添加到 `__init__.py` 和 `_FULL_CONFIG`
+- **分类测试放置** — 遵循现有模式将测试追加到 `tests/test_<category>_ops.py`
+- **三种生成模式** — 新建算子、替换已有、或并列自定义变体（v2）
+- **错误恢复** — 结构化重试协议，支持 MCP 重新生成和优化
+
+---
+
+## 目录结构
+
+```
+skills/kernelgen-for-flaggems/
+├── SKILL.md        # 技能定义（入口文件）
+├── LICENSE.txt     # Apache 2.0 许可证
+├── README.md       # 英文文档
+└── README_zh.md    # 本文档（中文版）
+```
+
+---
+
+## 相关技能
+
+- [`kernelgen`](../kernelgen/) — 通用版本，适用于任意 Python/Triton 仓库
+- [`kernelgen-for-vllm`](../kernelgen-for-vllm/) — vLLM 仓库专用版
+- [`kernelgen-submit-feedback`](../kernelgen-submit-feedback/) — 提交 bug 报告和反馈
+
+---
+
+## 许可证
+
+本项目基于 Apache 2.0 许可证。详见 [LICENSE.txt](LICENSE.txt)。

--- a/skills/kernelgen-for-flaggems/SKILL.md
+++ b/skills/kernelgen-for-flaggems/SKILL.md
@@ -1,0 +1,882 @@
+---
+name: kernelgen-for-flaggems
+description: >
+  Generate a FlagGems operator via kernelgen-mcp. Checks environment & MCP availability, calls the
+  code generator, places files in the correct FlagGems project locations, and runs accuracy +
+  benchmark tests. Use this skill when working in a FlagGems repository and need to generate GPU
+  kernel operators. Trigger when the user says things like "generate a FlagGems operator", "create
+  a kernel for FlagGems", or "/kernelgen-for-flaggems".
+argument-hint: "<operator_name> [--func-type <type>]"
+user-invokable: true
+compatibility: "Python 3.8+, FlagGems, PyTorch with CUDA, Triton"
+metadata:
+  version: "1.0.0"
+  author: flagos-ai
+  category: gpu-kernel-generation
+  tags: [kernelgen, flaggems, triton, gpu, mcp, operator-generation]
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+# KernelGen Skill — Generate FlagGems Operators via MCP
+
+You are an expert at generating GPU kernel operators for the FlagGems project using the `kernelgen-mcp` MCP service.
+
+**Tool usage**: This skill relies on the following capabilities:
+- **Shell**: execute shell commands (python, pip, pytest, etc.) via the Bash/shell tool
+- **Read**: read files from the codebase
+- **Write / Edit**: create or modify files
+- **Grep**: search file contents
+- **Glob**: find files by pattern
+- **MCP tools**: `mcp__kernelgen-mcp__generate_operator` and `mcp__kernelgen-mcp__optimize_triton`
+
+> **⚠️ MCP Prerequisite Check**: If the user has not configured the kernelgen MCP service (i.e., MCP tools are unavailable or calls fail),
+> immediately prompt the user to visit https://kernelgen.flagos.io/ to register and obtain the kernelgen MCP service URL and JWT Token,
+> then complete the configuration following Step 0b instructions before retrying. Do not proceed with subsequent steps if MCP is not ready.
+
+When you need user input or clarification, ask a question directly and wait for their reply.
+Always use the appropriate built-in tool rather than outputting commands for the user to run manually.
+
+## Step 0: Pre-flight — Environment & MCP Check
+
+### 0a. Check Python Environment
+
+Run the following diagnostic command:
+
+```bash
+python -c "import torch; import triton; import flag_gems; print('torch', torch.__version__); print('triton', triton.__version__); print('flag_gems', flag_gems.__version__); print('device', flag_gems.device)"
+```
+
+**If any import fails**, identify what's missing and use the shell tool to install it:
+
+| Missing package | Install command |
+|---|---|
+| `torch` | Do NOT auto-install. Ask the user for the correct install command, as the CUDA wheel variant depends on their environment. |
+| `triton` | `pip install triton` |
+| `flag_gems` | `pip install -e .` from the repo root, or `pip install flag_gems` |
+| `pytest` | `pip install pytest` |
+| `numpy` | `pip install numpy` |
+| `scipy` | `pip install scipy` |
+| `pyyaml` | `pip install pyyaml` |
+| `packaging` | `pip install packaging` |
+
+If `torch` is missing or has no CUDA support, run a separate GPU diagnostic:
+
+```bash
+python -c "import torch; print('cuda_version:', torch.version.cuda); print('cuda_available:', torch.cuda.is_available())"
+```
+
+Then diagnose:
+- If `torch.version.cuda` is `None` → torch is a CPU-only build. Ask the user to reinstall with CUDA.
+- If `torch.version.cuda` has a value but `torch.cuda.is_available() == False` → CUDA build but no GPU
+  detected. Warn the user that GPU tests will fail and ask how to proceed.
+
+If `flag_gems` is not installed, first verify `pyproject.toml` or `setup.py` exists in the current
+working directory (to confirm we're at the repo root). If found, run `pip install -e .`. If not
+found, ask the user for the correct repo root path.
+
+After installing, re-run the diagnostic via the shell tool to confirm everything works. Only proceed when all imports succeed.
+
+### 0b. Check MCP Availability
+
+Verify that the `kernelgen-mcp` MCP server is configured and reachable.
+
+Use the Read tool to read `.claude/settings.json` and look for an `mcpServers` entry whose key
+contains `kernelgen` (case-insensitive). If the file does not exist, treat it as "MCP not configured".
+
+**If the MCP server is NOT configured**, stop and print the following message to the user, then
+wait for the user to provide the URL and JWT token:
+
+```
+The kernelgen-mcp service is not yet configured. Please follow these steps:
+
+1. Visit https://kernelgen.flagos.io/ to register and obtain a JWT Token.
+2. Add the following MCP configuration to `.claude/settings.json` (replace <YOUR_URL> and <YOUR_JWT_TOKEN> with actual values):
+
+{
+  "mcpServers": {
+    "kernelgen-mcp": {
+      "type": "sse",
+      "url": "<YOUR_URL>",
+      "headers": {
+        "Authorization": "Bearer <YOUR_JWT_TOKEN>"
+      }
+    }
+  }
+}
+
+3. After configuration is complete, please re-run this command.
+```
+
+After the user provides the URL and JWT, use the Edit tool (or Write tool if the file doesn't exist)
+to write the configuration into `.claude/settings.json`, merging with any existing content. Then proceed.
+
+**If the MCP server IS configured**, proceed to Step 1.
+
+## Step 1: Understand the Operator Request
+
+Parse the user's description to determine:
+- `kernel_name`: operator name (e.g., `relu`, `softmax`, `gelu`, `layer_norm`).
+  Prefer names exactly as defined in `torch.ops.aten` (e.g., `relu`, `silu`, `neg`),
+  since registration uses the aten name.
+- `torch_call`: the actual Python call to invoke this op on a tensor. This is NOT always
+  `torch.<kernel_name>`. Determine it as follows:
+  1. If `torch.<kernel_name>` exists (`hasattr(torch, '<kernel_name>')` is True) → use `torch.<kernel_name>`
+  2. If not, check `torch.nn.functional.<kernel_name>` (e.g., `torch.nn.functional.layer_norm`)
+  3. If not, check `torch.special.<kernel_name>` or `torch.linalg.<kernel_name>`
+  4. As a last resort, use `torch.ops.aten.<kernel_name>.default`
+  Do NOT use `torch._C._nn` — it is an internal API that can break across PyTorch versions.
+  **Mandatory extra arguments**: If the chosen `torch_call` requires mandatory arguments beyond the
+  input tensor(s), you MUST include them with sensible defaults. Common cases:
+  - `torch.nn.functional.softmax(x, dim=-1)`
+  - `torch.nn.functional.log_softmax(x, dim=-1)`
+  - `torch.nn.functional.layer_norm(x, normalized_shape=x.shape[-1:])`
+  - `torch.nn.functional.dropout(x, p=0.5, training=False)`
+  - `torch.nn.functional.normalize(x, dim=-1)`
+  When in doubt, check the existing tests in the repo or the PyTorch docs for required arguments.
+  Omitting mandatory arguments (e.g., `torch.nn.functional.softmax(x)` without `dim`) will cause
+  runtime errors.
+  Store `<torch_call>` (including any mandatory extra arguments) — it will be used in tests and
+  benchmarks wherever the reference op is needed.
+- `func_desc`: what the operator does
+- `func_type`: one of the following categories (aligned with FlagGems test structure).
+  **Auto-infer from the operator signature when possible:**
+  - If 1 tensor input, no dim arg → `unary_pointwise`
+  - If operator has >=2 tensor inputs, no dim arg → `binary_pointwise`
+  - If has a `dim` argument → `reduction`
+  - If name contains `norm`, `softmax` (also matches `log_softmax`), `rmsnorm`, or `batchnorm` → `normalization`
+  - If name is `mm`, `matmul`, `bmm`, `addmm` → `blas`
+  - Otherwise → `other`
+  Confirm the inferred `func_type` with the user if ambiguous. Categories:
+  - `unary_pointwise` — single-input elementwise ops (relu, sigmoid, abs, etc.)
+  - `binary_pointwise` — two-input elementwise ops (add, mul, etc.)
+  - `reduction` — ops that reduce dimensions (sum, mean, max, etc.)
+  - `normalization` — norm ops (layer_norm, batch_norm, group_norm, etc.)
+  - `blas` — matrix operations (matmul, mm, bmm, etc.)
+  - `other` — everything else (indexing, special, etc.)
+- `arg_names`, `arg_type`, `arg_descs`, `output_arg_desc`: parameter information
+
+If the operator name is ambiguous, first check this common alias table before asking the user:
+
+| User says | Correct `kernel_name` (torch.ops.aten) |
+|---|---|
+| swish | `silu` |
+| negative / negate | `neg` |
+| power | `pow` |
+| square | `pow` (exp=2) |
+| cube | `pow` (exp=3) |
+| absolute | `abs` |
+| multiply | `mul` |
+| divide | `div` |
+| clip | `clamp` |
+| hard_swish | `hardswish` |
+| hard_sigmoid | `hardsigmoid` |
+| logarithm / ln | `log` |
+| exponential | `exp` |
+| hyperbolic_tangent | `tanh` |
+| square_root | `sqrt` |
+| cube_root | `cbrt` |
+| inverse_sqrt | `rsqrt` |
+| reciprocal / inverse | `reciprocal` |
+| minimum | `min` |
+| maximum | `max` |
+| floor_divide | `floor_divide` |
+| modulo / mod | `remainder` |
+
+If the alias is not in this table, ask the user to clarify.
+
+After determining `func_type`, derive the `<category>` value used for test/benchmark file paths:
+
+| func_type | category (for file paths) |
+|---|---|
+| `unary_pointwise` | `unary_pointwise` |
+| `binary_pointwise` | `binary_pointwise` |
+| `reduction` | `reduction` |
+| `normalization` | `norm` |
+| `blas` | `blas` |
+| `other` | `special` |
+
+Store this `<category>` value — it determines which `tests/test_<category>_ops.py` and
+`benchmark/test_<category>_perf.py` files to modify.
+
+## Step 2: Check Whether the Operator Already Exists
+
+Before calling the MCP generator, **thoroughly search** the codebase for existing implementations:
+
+1. **Core ops**: Use the Glob tool to check for `src/flag_gems/ops/<kernel_name>.py`
+2. **Experimental ops**: Use the Glob tool to check for `src/flag_gems/experimental_ops/<kernel_name>.py`
+3. **Registration**: Use the Grep tool to search `src/flag_gems/ops/__init__.py` and `src/flag_gems/__init__.py` for the op name
+4. **Aten registration**: Use the Grep tool to search for `torch.ops.aten.<kernel_name>` in the codebase (some registrations use the aten op reference instead of string names)
+5. **Tests**: Use the Grep tool to search `tests/test_*_ops.py` for `test_accuracy_<kernel_name>`
+6. **Benchmarks**: Use the Grep tool to search `benchmark/test_*_perf.py` for the op name in `forward_operations`
+
+### If the operator already exists
+
+Present findings to the user and ask them to choose one of the following:
+
+**Option A — Skip generation**: The operator already exists; do nothing.
+
+**Option B — Replace existing**: Overwrite the current implementation with MCP-generated code
+(adapted to FlagGems conventions). This will modify:
+  - `src/flag_gems/ops/<kernel_name>.py`
+  - Potentially update tests and benchmarks
+
+**Option C — Create a custom variant (side-by-side)**: Generate the operator under a different
+name so it coexists with the original. The naming convention is `<kernel_name>_v2` (or a
+user-specified suffix). This will:
+  - Create `src/flag_gems/ops/<kernel_name>_v2.py`
+  - Add a new import + `__all__` entry in `src/flag_gems/ops/__init__.py`
+  - Do **NOT** register it in `_FULL_CONFIG` (it won't override the aten dispatch)
+  - Create a standalone test in `experimental_tests/<kernel_name>_v2_test.py`
+  - Include a perf benchmark in that same test file using `GenericBenchmark`
+
+Only proceed to Step 3 after the user has made a choice.
+
+### If the operator does NOT exist
+
+Proceed directly to Step 3.
+
+## Step 3: Research Context (flagos_wiki)
+
+Before calling the MCP generator, use the Read tool to gather reference materials that improve generation quality:
+
+1. **Read similar operator code** from the codebase. For example:
+   - Unary pointwise → read `src/flag_gems/ops/abs.py` or `src/flag_gems/ops/sigmoid.py`
+   - Binary pointwise → read `src/flag_gems/ops/add.py`
+   - Reduction → read `src/flag_gems/ops/sum.py` or `src/flag_gems/ops/mean.py`
+   - Normalization → read `src/flag_gems/ops/layer_norm.py`
+   - BLAS → read `src/flag_gems/ops/mm.py`
+
+2. **Read the test pattern** from the matching test file to understand shapes, dtypes, assertions.
+
+3. **If replacing an existing op** (Option B), read the current implementation so the new version
+   can be compared / improved upon.
+
+4. Collect all findings and **summarize into concise notes** (not full file contents) to pass as
+   the `flagos_wiki` parameter. For example:
+   - `"abs.py uses pointwise_dynamic with DEFAULT promotion, returns tl.abs(x)"`
+   - `"sigmoid.py uses INT_TO_FLOAT promotion, returns 1/(1+tl.exp(-x))"`
+   - `"test pattern: @pytest.mark.xxx, POINTWISE_SHAPES, FLOAT_DTYPES, gems_assert_close"`
+
+   If the `mcp__kernelgen-mcp__generate_operator` tool supports a `flagos_wiki` (or similarly named
+   `context`/`references`) parameter, pass the collected notes. If the MCP call fails with an
+   error containing `unexpected argument`, `unknown field`, `invalid schema`, or similar, retry
+   the call without the `flagos_wiki` field.
+
+## Step 4: Call kernelgen-mcp
+
+Invoke `mcp__kernelgen-mcp__generate_operator` with the parameters gathered above, including the
+`flagos_wiki` list for reference context.
+
+**Set the iteration counter**: `iteration_count = 1`. This tracks total MCP calls for the final report.
+
+The MCP returns four code blocks:
+- `torch_code` — PyTorch reference implementation
+- `triton_code` — Triton kernel implementation
+- `test_func_code` — accuracy test code
+- `benchmark_func_code` — performance benchmark code
+
+## Step 5: Adapt and Place Code into the FlagGems Project
+
+This is the most critical step. The generated code must be transformed to match FlagGems conventions.
+The exact placement depends on the user's choice in Step 2.
+
+**Transformation rules for pointwise ops**: The MCP generator will almost always output raw
+pointer-based Triton code. For core pointwise ops, you MUST **always** rewrite it into the
+`pointwise_dynamic` elementwise style:
+- The `@triton.jit` kernel function receives **scalar elements** (not pointers)
+- `pointwise_dynamic` handles all pointer arithmetic, tiling, and masking automatically
+- The kernel only contains the elementwise math logic (e.g., `return tl.maximum(x, 0)`)
+- **Remove ALL** `tl.load()`, `tl.store()`, pointer arithmetic (`ptr + offsets`), mask logic,
+  and BLOCK_SIZE parameters — these are incompatible with `pointwise_dynamic`
+- Only keep the pure math expression that transforms input element(s) to output element(s)
+
+Examples of correct `pointwise_dynamic` kernels (keep ONLY the scalar `tl.*` math):
+```python
+# relu: return tl.maximum(x, 0)
+# exp:  return tl.exp(x)
+# silu: return x * tl.sigmoid(x)
+# add:  return x + y
+```
+
+Do NOT keep `offsets`, `mask`, `n_elements`, `BLOCK_SIZE`, or any tiling logic.
+
+**CRITICAL**: The MCP Triton code MUST NOT be copied directly for core ops. Always rewrite it
+following FlagGems `pointwise_dynamic` conventions. Never trust the raw MCP code — it will
+almost always be pointer-style which is incompatible with `pointwise_dynamic`.
+
+---
+
+### Path 1: New operator / Replace existing (Option B or new op)
+
+#### 5a. Operator Implementation → `src/flag_gems/ops/<kernel_name>.py`
+
+Use the Write tool (new file) or Edit tool (replacing existing) to create the operator file
+following FlagGems conventions:
+
+**Unary pointwise template:**
+```python
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=<PROMOTION_METHODS>)
+@triton.jit
+def <kernel_name>_forward(x):
+    return ...
+
+
+def <kernel_name>(A):
+    logger.debug("GEMS <KERNEL_NAME> FORWARD")
+    return <kernel_name>_forward(A)
+```
+
+**Binary pointwise template:**
+```python
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=<PROMOTION_METHODS>)
+@triton.jit
+def <kernel_name>_forward(x, y):
+    return ...
+
+
+def <kernel_name>(A, B):
+    logger.debug("GEMS <KERNEL_NAME> FORWARD")
+    return <kernel_name>_forward(A, B)
+```
+
+Choose the correct template based on `func_type`. For non-pointwise ops (reduction, BLAS,
+normalization), do NOT use either template — instead read a similar existing op and follow
+its pattern.
+
+**For in-place variants**: Read an existing in-place operator (e.g., `relu.py`) to find the
+exact call pattern used in this repo, then follow it. Common patterns include:
+
+```python
+def <kernel_name>_(A):
+    logger.debug("GEMS <KERNEL_NAME>_ FORWARD")
+    return <kernel_name>_forward(A, out0=A)
+```
+
+Do NOT assume the in-place parameter name — it may be `out0=A`, `out=A`, or another convention.
+Always verify by reading an existing in-place operator first.
+
+Key conventions:
+- Use `pointwise_dynamic` decorator from `flag_gems.utils` for pointwise ops
+- Use `triton.jit` decorator
+- The kernel function takes raw tensor elements (not pointers) — `pointwise_dynamic` handles the boilerplate
+- **Unary ops**: kernel has one parameter `(x)`, e.g. `def relu_forward(x)`
+- **Binary ops**: kernel has two parameters `(x, y)`, e.g. `def add_forward(x, y)`
+- Promotion methods — **always read a similar existing operator first** and copy its promotion
+  method. If no similar operator exists, use these guidelines as fallback:
+  - `INT_TO_FLOAT`: ops that always produce float output (exp, log, sigmoid, tanh, sqrt, etc.)
+  - `COMPLEX_TO_FLOAT`: ops that reduce complex to real (abs)
+  - `DEFAULT`: ops that preserve input dtype (relu, neg, add, mul, clamp, etc.)
+  - **Template placeholder** `<PROMOTION_METHODS>` must expand to the full list:
+    - Unary ops: `[(0, "DEFAULT")]` or `[(0, "INT_TO_FLOAT")]`
+    - Binary ops: `[(0, "DEFAULT"), (1, "DEFAULT")]` or `[(0, "INT_TO_FLOAT"), (1, "INT_TO_FLOAT")]`
+  - **When in doubt, prefer reading the repo** — promotion behavior is subtle and repo-specific.
+    Promotion rules in FlagGems are repo-specific and must never be guessed if a similar operator exists.
+- The wrapper function takes `A` as the input tensor parameter name (NOT `self`)
+- Include `logger.debug("GEMS <NAME> FORWARD")` in the wrapper
+- For in-place variants, read an existing in-place op first and copy its exact call pattern
+- For non-pointwise ops (reduction, BLAS, normalization, etc.), follow the specific pattern of similar existing ops — do NOT force the `pointwise_dynamic` pattern on them
+
+#### 5b. Register the Operator
+
+Use the Edit tool to make these changes:
+
+1. **`src/flag_gems/ops/__init__.py`**: Add import and `__all__` entry (in alphabetical order):
+   ```python
+   from flag_gems.ops.<kernel_name> import <kernel_name>, <kernel_name>_
+   ```
+
+2. **`src/flag_gems/__init__.py`**: Add to `_FULL_CONFIG` tuple (in alphabetical order).
+   **IMPORTANT**: First read the existing `_FULL_CONFIG` entries to match the exact registration
+   format used by this repo. Different versions may use different styles:
+   - String style: `("relu", relu)`
+   - Aten op style: `(torch.ops.aten.relu.default, relu)`
+   Copy the pattern from existing entries. Do NOT guess the format.
+   Insert the new entry in **alphabetical order** — do not change the order of existing entries.
+
+#### 5c. Accuracy Test → `tests/test_<category>_ops.py`
+
+Do NOT create a new test file. Use the Edit tool to add the test function to the appropriate existing test file:
+- Unary pointwise: `tests/test_unary_pointwise_ops.py`
+- Binary pointwise: `tests/test_binary_pointwise_ops.py`
+- Reduction: `tests/test_reduction_ops.py`
+- BLAS: `tests/test_blas_ops.py`
+- Norm: `tests/test_norm_ops.py`
+- Special: `tests/test_special_ops.py`
+
+Follow the existing test pattern:
+```python
+@pytest.mark.<kernel_name>
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_<kernel_name>(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp)
+
+    ref_out = <torch_call>(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.<kernel_name>(inp)
+
+    gems_assert_close(res_out, ref_out, dtype)
+```
+
+Key conventions:
+- Use `flag_gems.device` not `"cuda"`
+- Use `to_reference()` to create reference tensors
+- Use `flag_gems.use_gems()` context manager for the FlagGems call
+- Use `gems_assert_close` or `gems_assert_equal` for comparison
+- Mark with `@pytest.mark.<kernel_name>`
+- If the marker `<kernel_name>` is not already registered, find where markers are defined
+  (check in this order):
+  1. `pytest.ini` — look for `[pytest] markers`
+  2. `pyproject.toml` — look for `[tool.pytest.ini_options] markers`
+  3. `setup.cfg` — look for `[tool:pytest] markers`
+  Add the marker to whichever file already has a markers section.
+  If none of them has a markers section, create one in `pytest.ini`.
+- Use `POINTWISE_SHAPES`, `FLOAT_DTYPES` etc. from `accuracy_utils`
+
+#### 5d. Performance Benchmark → `benchmark/test_<category>_perf.py`
+
+Do NOT create a new benchmark file. Read the target benchmark file first, then use the Edit tool
+to append the new tuple into the existing `forward_operations` list (find the list definition and
+insert in alphabetical order). Follow the exact tuple format already used in the file.
+- Unary pointwise: `benchmark/test_unary_pointwise_perf.py`
+- Binary pointwise: `benchmark/test_binary_pointwise_perf.py`
+- Reduction: `benchmark/test_reduction_perf.py`
+- Norm: `benchmark/test_norm_perf.py`
+- BLAS: `benchmark/test_blas_perf.py`
+- Special: `benchmark/test_special_perf.py`
+
+For unary pointwise ops, simply add a tuple to `forward_operations`:
+```python
+("<kernel_name>", <torch_call>, FLOAT_DTYPES),
+```
+
+For inplace ops, **only** add to `forward_inplace_operations` if PyTorch provides an inplace version.
+Verify by running `hasattr(torch, "<kernel_name>_")` or checking if `torch.<kernel_name>_` exists
+(e.g., `torch.relu_` exists, but `torch.gelu_` and `torch.softmax_` do not).
+If the inplace op requires extra mandatory arguments (e.g., `clamp_` needs `min`/`max`), verify
+the signature via `import inspect; inspect.signature(torch.<kernel_name>_)` before adding it.
+**Important**: Always use `torch.<kernel_name>_` for the inplace reference — do NOT derive from
+`<torch_call>` (e.g., `torch.nn.functional.relu_` does not exist):
+```python
+("<kernel_name>_", torch.<kernel_name>_, FLOAT_DTYPES),
+```
+
+---
+
+### Path 2: Custom variant side-by-side (Option C)
+
+#### 5a. Operator Implementation → `src/flag_gems/ops/<kernel_name>_v2.py`
+
+Use the Write tool to create the file. Use the **raw Triton pointer-based style** (same as
+`experimental_ops/`), since this operator does NOT go through `pointwise_dynamic` dispatch.
+Keep the MCP-generated Triton code mostly as-is but ensure it:
+- Is self-contained (no flag_gems.utils imports needed)
+- Has proper `@triton.jit` kernel with pointer args, mask, BLOCK_SIZE
+- **Has a Python wrapper function** that computes the grid and launches the kernel.
+  **Ensure all kernel meta parameters (BLOCK_SIZE, etc.) are passed** — either via
+  `@triton.autotune` (which sets them automatically) or as explicit keyword arguments:
+  ```python
+  # Option A: with @triton.autotune on the kernel (BLOCK_SIZE auto-set)
+  def <kernel_name>_v2(x: torch.Tensor) -> torch.Tensor:
+      assert x.is_cuda, "Triton kernel requires CUDA tensor"
+      assert x.is_contiguous(), "Input tensor must be contiguous"
+      output = torch.empty_like(x)
+      n_elements = x.numel()
+      grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+      _<kernel_name>_v2_kernel[grid](x, output, n_elements)
+      return output
+
+  # Option B: without autotune (adaptive BLOCK_SIZE heuristic)
+  def <kernel_name>_v2(x: torch.Tensor) -> torch.Tensor:
+      assert x.is_cuda, "Triton kernel requires CUDA tensor"
+      assert x.is_contiguous(), "Input tensor must be contiguous"
+      output = torch.empty_like(x)
+      n_elements = x.numel()
+      if n_elements < 4096:
+          BLOCK_SIZE = 256
+      elif n_elements < 65536:
+          BLOCK_SIZE = 512
+      else:
+          BLOCK_SIZE = 1024
+      grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+      _<kernel_name>_v2_kernel[grid](x, output, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+      return output
+  ```
+  Adapt the grid computation to match the kernel pattern (elementwise vs row-wise).
+- Exports the wrapper function named `<kernel_name>_v2`
+
+Alternatively, if the user prefers the `pointwise_dynamic` style, use that and just rename
+the function to `<kernel_name>_v2`.
+
+#### 5b. Registration (limited)
+
+Use the Edit tool to make these changes:
+
+1. **`src/flag_gems/ops/__init__.py`**: Add import and `__all__` entry:
+   ```python
+   from flag_gems.ops.<kernel_name>_v2 import <kernel_name>_v2
+   ```
+2. Do **NOT** add to `_FULL_CONFIG` in `src/flag_gems/__init__.py` — the variant must NOT
+   override the aten dispatch for the original operator.
+
+#### 5c. Standalone Test + Benchmark → `experimental_tests/<kernel_name>_v2_test.py`
+
+Use the Write tool to create a single self-contained test file following the `experimental_tests/` pattern:
+
+```python
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.ops.<kernel_name>_v2 import <kernel_name>_v2 as gems_op
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        torch.testing.assert_close(res, ref, **kwargs)
+
+from benchmark.performance_utils import GenericBenchmark
+
+
+def to_reference(inp, upcast=False):
+    ref_inp = inp.to("cpu") if hasattr(inp, "to") else inp
+    if upcast:
+        ref_inp = ref_inp.to(torch.float64)
+    return ref_inp
+
+
+@pytest.mark.<kernel_name>_v2
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_<kernel_name>_v2_accuracy(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp)
+    ref_out = <torch_call>(ref_inp)
+    act_out = gems_op(inp)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.<kernel_name>_v2
+def test_<kernel_name>_v2_perf():
+    def input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=device)
+        yield inp,
+
+    bench = GenericBenchmark(
+        input_fn=input_fn,
+        op_name="<kernel_name>_v2",
+        torch_op=<torch_call>,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+    return bench.run()
+```
+
+---
+
+## Step 5.5: Pre-test Validation
+
+Before running the full test suite, perform two quick checks:
+
+### 5.5a. Lint / Format Check
+
+If the repo uses linting tools (ruff, black, isort, flake8), run them on the changed files to
+catch style issues early. Use the shell tool:
+
+```bash
+python -m ruff check src/flag_gems/ops/<kernel_name>.py --fix
+python -m ruff format src/flag_gems/ops/<kernel_name>.py
+```
+
+If `ruff` is not installed, check for other formatters in `pyproject.toml` or `setup.cfg` and
+use those. If no linter is configured, skip this step.
+
+### 5.5b. Triton Compile Smoke Test
+
+Triton kernel compile errors only surface on first invocation (JIT compilation).
+This smoke test ensures JIT compilation happens before pytest runs, catching compile
+errors early with clear diagnostics rather than buried in test output:
+
+**For Path 1:**
+
+Adapt the smoke test call based on `func_type`:
+- **Unary**: `torch.<kernel_name>(inp)`
+- **Binary**: `torch.<kernel_name>(inp, inp)` (pass the same tensor twice)
+- **Reduction**: `torch.<kernel_name>(inp)` or `torch.<kernel_name>(inp, dim=-1)` if `dim` is required
+- **Normalization / other**: use `<torch_call>` with appropriate arguments
+
+Use `inspect.signature` to infer missing arguments (e.g., weight, bias, eps for layer_norm) before constructing the smoke test. This ensures all mandatory parameters are included with sensible defaults, avoiding runtime errors from incomplete function calls.
+
+```bash
+python -c "
+import torch, flag_gems
+for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+    for shape in [(1,), (4,), (128,), (4, 128), (0,)]:
+        inp = torch.empty(shape, dtype=dtype, device=flag_gems.device) if shape == (0,) else torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        with flag_gems.use_gems():
+            out = <SMOKE_TEST_CALL>  # e.g. torch.relu(inp) or torch.add(inp, inp)
+        print(f'Smoke test passed: {dtype}, shape={shape}')
+"
+```
+
+**For Path 2:**
+```bash
+python -c "
+import torch, flag_gems
+from flag_gems.ops.<kernel_name>_v2 import <kernel_name>_v2
+for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+    for shape in [(1,), (4,), (128,), (4, 128), (0,)]:
+        inp = torch.empty(shape, dtype=dtype, device=flag_gems.device) if shape == (0,) else torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        out = <kernel_name>_v2(inp)  # For binary: <kernel_name>_v2(inp, inp)
+        print(f'Smoke test passed: {dtype}, shape={shape}')
+"
+```
+
+The `(0,)` shape tests the empty-tensor edge case (numel==0), which often causes kernel crashes.
+
+If this fails, read the error and fix the kernel before proceeding to Step 6.
+
+## Step 6: Run Accuracy Tests
+
+Run the accuracy tests for the newly added operator.
+Assume the current working directory is the repository root.
+
+**For Path 1 (new / replace):**
+```bash
+python -m pytest tests/test_<category>_ops.py -m <kernel_name> -v
+```
+
+**For Path 2 (custom variant):**
+```bash
+python -m pytest experimental_tests/<kernel_name>_v2_test.py -v -k "accuracy"
+```
+
+Report the results to the user. If tests fail, follow the **error classification and retry
+protocol** below. This protocol strictly limits self-fix attempts to prevent infinite loops.
+
+### Error Classification
+
+First, classify the error into one of two categories:
+
+**Category A — Compilation / Import errors** (model may attempt 1 self-fix):
+- `ImportError`, `ModuleNotFoundError` — wrong import path or missing module
+- `SyntaxError` — Python syntax issue
+- `TritonCompilationError`, `CompilationError` — Triton kernel compile failure
+- `NameError` — undefined variable or function
+- `TypeError` in function call signature — wrong number/type of arguments
+- `AttributeError` — wrong attribute access on a module or object
+
+**Category B — Algorithm / Numerical accuracy errors** (do NOT self-fix):
+- `AssertionError` from `torch.testing.assert_close` or `gems_assert_close` — numerical mismatch
+- Wrong output values (results don't match reference)
+- Shape mismatch in output tensors
+- NaN or Inf in output
+- Any error that indicates the kernel logic is incorrect
+
+### Retry Protocol (strictly follow this order)
+
+**Step 6a. (Category A only) Self-fix — maximum 1 attempt:**
+If the error is Category A (compilation/import), you may attempt exactly ONE fix:
+1. Use the Read tool to examine the error traceback carefully.
+2. Apply a targeted fix using the Edit tool (e.g., fix import path, fix syntax, fix argument name).
+3. Use the shell tool to re-run the tests.
+4. If the test **passes** → proceed to Step 7.
+5. If the test **still fails** → proceed to Step 6b. Do NOT attempt a second self-fix.
+
+**If the error is Category B (algorithm/accuracy), skip Step 6a entirely** — go directly
+to Step 6b. Do NOT attempt to fix algorithm logic yourself, as this typically leads to
+an endless fix-retry loop without converging. The MCP service has better optimization
+capabilities for these issues.
+
+**Step 6b. MCP re-generation — pass error context to generate_operator:**
+Re-call `mcp__kernelgen-mcp__generate_operator` with the **same parameters as Step 4**,
+but add the error information to `flagos_wiki` as additional hints.
+**Increment**: `iteration_count += 1`.
+Keep `flagos_wiki` concise — maximum 10 items total. If retrying multiple times, replace
+earlier error entries rather than appending, to avoid bloating the prompt.
+```python
+flagos_wiki = [
+    # ... original flagos_wiki items from Step 3 ...
+    "Previous generation failed accuracy test: <brief error description>",
+    "Error was: <key line from traceback>",
+    "Fix hint: <your analysis, e.g. 'promotion method should be INT_TO_FLOAT not DEFAULT'>"
+]
+```
+Replace the kernel code with the new MCP output, re-run tests.
+- If tests **pass** → proceed to Step 7.
+- If tests **still fail** → proceed to Step 6c.
+
+**Step 6c. MCP optimization — pass error context to optimize_triton:**
+Try `mcp__kernelgen-mcp__optimize_triton` with the current kernel code and the
+`check_result` parameter containing the error traceback.
+**Increment**: `iteration_count += 1`. This endpoint can fix
+memory access patterns, index calculations, and numerical issues.
+Replace the kernel code with the optimized output, re-run tests.
+- If tests **pass** → proceed to Step 7.
+- If tests **still fail** → proceed to Step 6d.
+
+**Step 6d. Stop and report:**
+Do not keep retrying. Report the failure to the user with:
+- The specific test failures and error messages
+- Your analysis of what might be wrong
+- Suggestion to try with different `func_type` or additional `flagos_wiki` hints
+
+## Step 7: Run Performance Benchmark
+
+Run the performance benchmark.
+
+**For Path 1 (new / replace):**
+```bash
+python -m pytest benchmark/test_<category>_perf.py -m <kernel_name> -v
+```
+
+**For Path 2 (custom variant):**
+```bash
+python -m pytest experimental_tests/<kernel_name>_v2_test.py -v -k "perf"
+```
+
+Look for lines in the output containing keywords like `speedup`, `latency`, `gems`, `torch`, or
+timing values. Use regex patterns to extract numbers, accounting for various formats:
+- `(\d+(?:\.\d+)?)\s*(us|ms|s)` — number with space before unit
+- `(\d+(?:\.\d+)?)(ms|us|s)` — number directly attached to unit (e.g., `0.123ms`)
+- `(\d+(?:\.\d+)?)\s*(us|ms|s)/iter` — number with per-iteration suffix (e.g., `0.123 ms/iter`)
+- `time:\s*(\d+(?:\.\d+)?)` — labeled timing values
+- `(?i)avg:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — average timing value (e.g., `avg: 0.123 ms`)
+- `(?i)mean:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — mean timing value (pytest-benchmark format, e.g., `mean: 0.123 ms`)
+- `(?i)median:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — median timing value
+- `(?i)Torch.*?(\d+(?:\.\d+)?)\s*(us|ms|s)` — PyTorch reference time (case-insensitive)
+- `(?i)GEMS.*?(\d+(?:\.\d+)?)\s*(us|ms|s)` — FlagGems kernel time (case-insensitive)
+- `(?i)(flag_gems|gems).*?(\d+(?:\.\d+)?)\s*(us|ms|s)` — FlagGems kernel time (alternate)
+- `(?i)(torch|pytorch).*?(\d+(?:\.\d+)?)\s*(us|ms|s)` — PyTorch time (case-insensitive)
+
+**Do not just copy the raw table** — always compute and report actual speedup ratios.
+
+If a speedup metric is printed directly, extract and report it. Otherwise compute:
+`speedup = torch_latency / gems_latency` (>1.0 means gems is faster).
+
+**Note**: Triton kernels are JIT-compiled on first invocation, which adds significant overhead.
+If benchmark results look unreasonably slow on the first config, check whether the benchmark
+framework includes a warmup phase. If not, the first data point may be an outlier — **if the
+first timing sample is >5x larger than the median of remaining samples, exclude it** from the
+average speedup calculation and note "first sample excluded (Triton JIT compile overhead)" in
+the report. Triton JIT compilation is detected when the first invocation is disproportionately
+slow — always ignore such outliers when computing average speedup.
+
+## Step 8: Summary
+
+Provide a clear summary to the user with **exact numbers** extracted from test and benchmark
+output:
+
+```
+=== KernelGen Operator Generation Report ===
+
+Operator Name: <kernel_name>
+Generation Mode: New / Replace Existing / Custom Variant (v2)
+Operator Type: <func_type>
+
+File Changes:
+  - [New/Modified] src/flag_gems/ops/<kernel_name>.py
+  - [Modified] src/flag_gems/ops/__init__.py
+  - [Modified] src/flag_gems/__init__.py
+  - [Modified] tests/test_<category>_ops.py
+  - [Modified] benchmark/test_<category>_perf.py
+
+Accuracy Tests: <N> passed, <M> failed (total <N+M> test cases)
+  Pass Rate: <N/(N+M)*100>%
+  Failed Cases: <list failed test names if any, or "None">
+
+Performance Benchmark:
+  Avg Speedup: <X.XX>x vs PyTorch reference
+  Best Speedup: <X.XX>x (shape=<S>, dtype=<D>)
+  Worst Speedup: <X.XX>x (shape=<S>, dtype=<D>)
+  (If benchmark was not run or failed, write "Incomplete" and explain why)
+
+MCP Iterations: <iteration_count> (write 1 if first generation passed)
+
+Performance Analysis:
+  <Assess based on average speedup:
+   - Speedup > 5.0x → "Extreme fusion success, typical for fused multi-op kernels"
+   - Speedup > 3.0x → "Excellent compute-bound optimization, significant kernel fusion benefit"
+   - Speedup > 2.0x → "Compute-bound optimization effective, significant speedup achieved"
+   - Speedup 1.2x ~ 2.0x → "Moderate speedup, kernel likely balanced between compute and memory"
+   - Speedup 0.5x ~ 1.2x → "Kernel likely memory-bound, limited optimization headroom"
+   - Speedup < 0.5x → "Kernel slower than PyTorch reference — likely suboptimal memory access pattern">
+
+Issues and Fixes: (if any)
+```
+
+**How to extract the numbers:**
+- **Pass/fail counts**: Parse pytest output for the line matching `X passed` or `X passed, Y failed`.
+  Use regex pattern `(\d+) passed` and `(\d+) failed` to extract.
+- **Speedup**: Parse benchmark output for FlagGems vs PyTorch time values. Calculate
+  `speedup = torch_latency / gems_latency` for each config. Report min, max, and average.
+  - **Do not just copy the raw table** — always compute and report the actual speedup ratios.
+
+**After presenting the summary, check the speedup:**
+
+- **If average speedup < 0.5x** (kernel slower than PyTorch), proactively warn the user:
+  ```
+  ⚠️ The generated Triton kernel is slower than the PyTorch reference implementation.
+  This is typically caused by suboptimal memory access patterns or improper block size configuration.
+  Would you like to use /kernelgen_optimizer to optimize this kernel's performance?
+  ```
+
+- **If average speedup is 0.5x ~ 1.2x**, ask the user:
+  ```
+  Current speedup is low (<X.XX>x), there may be room for optimization.
+  Would you like to use /kernelgen_optimizer to try improving performance?
+  ```
+
+- **If average speedup > 1.2x**, no action needed — report the result normally.
+
+## Important Notes
+
+- **`kernel_name` must match the `torch` API name** (e.g., `silu` not `swish`, `neg` not `negate`).
+  The accuracy test calls `torch.<kernel_name>(...)`, so a mismatch will cause test failures.
+- **Never overwrite existing operators** without explicit user permission (Step 2 choice)
+- **Always use `pointwise_dynamic`** for core pointwise ops — do NOT write raw pointer-based Triton kernels
+  for core ops. Raw pointer style is only for custom variants (Option C / Path 2).
+- **Follow alphabetical ordering** when adding entries to `__init__.py` and `__all__`
+- **Match the existing code style** exactly — read existing files first and copy the pattern
+  (imports, logging, naming conventions, registration format)
+- **Benchmark follow the existing pattern** in the file — do NOT invent new patterns for
+  `forward_operations` or `forward_inplace_operations`
+- If accuracy tests fail, try to fix the operator. If benchmark is slow, consider calling
+  `mcp__kernelgen-mcp__optimize_triton` to optimize the kernel
+- When creating a custom variant, always make it clear that it does NOT override the aten dispatch
+  to avoid conflicts with the existing operator
+- **Speedup formula**: `speedup = torch_latency / gems_latency` (values > 1.0 mean gems is faster)
+- **Always use built-in tools** (shell, Read, Write, Edit, Grep, Glob) instead of
+  outputting commands or code snippets for the user to execute manually

--- a/skills/kernelgen-for-vllm/LICENSE.txt
+++ b/skills/kernelgen-for-vllm/LICENSE.txt
@@ -1,0 +1,200 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get an
+      OpenPGP-compatible signature of your completed statement.
+
+   Copyright 2026 BAAI (Beijing Academy of Artificial Intelligence)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/kernelgen-for-vllm/README.md
+++ b/skills/kernelgen-for-vllm/README.md
@@ -1,0 +1,81 @@
+# kernelgen-for-vllm: GPU Kernel Operator Generation for vLLM
+
+[中文版](README_zh.md)
+
+## Overview
+
+`kernelgen-for-vllm` is an AI coding skill that generates GPU kernel operators specifically for the vLLM project via the `kernelgen-mcp` MCP service.
+
+### Problem Statement
+
+vLLM has specific conventions for kernel implementation: SPDX license headers, `vllm.logger.init_logger` logging, `@triton.autotune` configurations, specific file placement patterns (`vllm/kernels/`, `csrc/`, `tests/kernels/`), and custom op registration (`vllm/_custom_ops.py`). Generating code that follows all these conventions manually is complex and error-prone.
+
+This skill automates the entire vLLM-specific workflow: **environment check → MCP generation → vLLM convention adaptation → operator registration → accuracy testing → benchmarking**, spanning 9 steps with vLLM-aware code transformation.
+
+### Usage
+
+```bash
+# Generate a vLLM kernel operator
+/kernelgen-for-vllm rms_norm
+
+# Generate with explicit function type
+/kernelgen-for-vllm silu_and_mul --func-type activation
+```
+
+| Argument | Required | Default | Description |
+|---|---|---|---|
+| `operator_name` | Yes | — | Operator name in snake_case (e.g. `rms_norm`, `silu_and_mul`, `rotary_embedding`) |
+| `--func-type` | No | Auto-inferred | One of: `activation`, `norm`, `attention`, `quantization`, `moe`, `sampling`, `other` |
+
+---
+
+## Generation Pipeline (9 Steps)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Step 0   Pre-flight: Environment & MCP Check            │
+│  Step 1   Understand the Operator Request                │
+│  Step 2   Check Whether Operator Already Exists          │
+│  Step 3   Research Context (flagos_wiki)                 │
+│  Step 4   Call kernelgen-mcp                             │
+│  Step 5   Adapt and Place Code (vLLM conventions)        │
+│  Step 6   Run Accuracy Tests                             │
+│  Step 7   Run Performance Benchmark                      │
+│  Step 8   Summary Report                                 │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Key Features
+
+- **vLLM-native code** — generates Triton kernels with SPDX headers, `init_logger`, and proper `@triton.autotune`
+- **Smart file placement** — places kernels in `vllm/kernels/`, tests in `tests/kernels/`, benchmarks in `benchmarks/kernels/`
+- **Custom op registration** — integrates with `vllm/_custom_ops.py` when applicable
+- **Three generation modes** — new operator, replace existing, or side-by-side custom variant (v2)
+- **Comprehensive testing** — per-dtype tolerances (fp32: 1e-5, fp16: 1e-2, bf16: 2e-2)
+- **Error recovery** — structured retry protocol with MCP re-generation and optimization
+
+---
+
+## Directory Structure
+
+```
+skills/kernelgen-for-vllm/
+├── SKILL.md        # Skill definition (entry point)
+├── LICENSE.txt     # Apache 2.0 license
+├── README.md       # This document (English)
+└── README_zh.md    # Chinese version
+```
+
+---
+
+## Related Skills
+
+- [`kernelgen`](../kernelgen/) — General purpose version for any Python/Triton repository
+- [`kernelgen-for-flaggems`](../kernelgen-for-flaggems/) — Specialized for FlagGems repositories
+- [`kernelgen-submit-feedback`](../kernelgen-submit-feedback/) — Submit bug reports and feedback
+
+---
+
+## License
+
+This project is licensed under the Apache 2.0 License. See [LICENSE.txt](LICENSE.txt) for details.

--- a/skills/kernelgen-for-vllm/README_zh.md
+++ b/skills/kernelgen-for-vllm/README_zh.md
@@ -1,0 +1,79 @@
+# kernelgen-for-vllm：vLLM GPU 算子生成
+
+## 概述
+
+`kernelgen-for-vllm` 是一个 AI 编程技能，通过 `kernelgen-mcp` MCP 服务专门为 vLLM 项目生成 GPU 算子。
+
+### 解决的问题
+
+vLLM 项目有特定的算子实现规范：SPDX 许可证头、`vllm.logger.init_logger` 日志记录、`@triton.autotune` 配置、特定的文件放置模式（`vllm/kernels/`、`csrc/`、`tests/kernels/`）以及自定义算子注册（`vllm/_custom_ops.py`）。手动编写符合所有这些规范的代码既复杂又容易出错。
+
+本技能自动化了 vLLM 特定的工作流程：**环境检查 → MCP 代码生成 → vLLM 规范适配 → 算子注册 → 准确性测试 → 性能基准测试**，涵盖 9 个步骤，支持 vLLM 感知的代码转换。
+
+### 使用方式
+
+```bash
+# 生成 vLLM 算子
+/kernelgen-for-vllm rms_norm
+
+# 指定函数类型
+/kernelgen-for-vllm silu_and_mul --func-type activation
+```
+
+| 参数 | 必填 | 默认值 | 说明 |
+|---|---|---|---|
+| `operator_name` | 是 | — | snake_case 格式的算子名称（如 `rms_norm`、`silu_and_mul`、`rotary_embedding`） |
+| `--func-type` | 否 | 自动推断 | 可选: `activation`、`norm`、`attention`、`quantization`、`moe`、`sampling`、`other` |
+
+---
+
+## 生成流水线（9 步）
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  步骤 0   预检：环境与 MCP 检查                           │
+│  步骤 1   理解算子需求                                    │
+│  步骤 2   检查算子是否已存在                               │
+│  步骤 3   研究上下文（flagos_wiki）                        │
+│  步骤 4   调用 kernelgen-mcp                              │
+│  步骤 5   适配代码（vLLM 规范）                            │
+│  步骤 6   运行准确性测试                                   │
+│  步骤 7   运行性能基准测试                                 │
+│  步骤 8   生成报告                                        │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 核心特性
+
+- **vLLM 原生代码** — 生成带有 SPDX 头、`init_logger` 和正确 `@triton.autotune` 的 Triton 算子
+- **智能文件放置** — 算子放到 `vllm/kernels/`，测试放到 `tests/kernels/`，基准测试放到 `benchmarks/kernels/`
+- **自定义算子注册** — 在适用时集成 `vllm/_custom_ops.py`
+- **三种生成模式** — 新建算子、替换已有、或并列自定义变体（v2）
+- **全面测试** — 按数据类型精度设置容差（fp32: 1e-5, fp16: 1e-2, bf16: 2e-2）
+- **错误恢复** — 结构化重试协议，支持 MCP 重新生成和优化
+
+---
+
+## 目录结构
+
+```
+skills/kernelgen-for-vllm/
+├── SKILL.md        # 技能定义（入口文件）
+├── LICENSE.txt     # Apache 2.0 许可证
+├── README.md       # 英文文档
+└── README_zh.md    # 本文档（中文版）
+```
+
+---
+
+## 相关技能
+
+- [`kernelgen`](../kernelgen/) — 通用版本，适用于任意 Python/Triton 仓库
+- [`kernelgen-for-flaggems`](../kernelgen-for-flaggems/) — FlagGems 仓库专用版
+- [`kernelgen-submit-feedback`](../kernelgen-submit-feedback/) — 提交 bug 报告和反馈
+
+---
+
+## 许可证
+
+本项目基于 Apache 2.0 许可证。详见 [LICENSE.txt](LICENSE.txt)。

--- a/skills/kernelgen-for-vllm/SKILL.md
+++ b/skills/kernelgen-for-vllm/SKILL.md
@@ -1,0 +1,1020 @@
+---
+name: kernelgen-for-vllm
+description: >
+  Generate a vLLM operator/kernel via kernelgen-mcp. Checks environment & MCP availability, calls
+  the code generator, places files in the correct vLLM project locations, and runs accuracy +
+  benchmark tests. Use this skill when working in a vLLM repository and need to generate GPU kernel
+  operators. Trigger when the user says things like "generate a vLLM kernel", "create an operator
+  for vLLM", or "/kernelgen-for-vllm".
+argument-hint: "<operator_name> [--func-type <type>]"
+user-invokable: true
+compatibility: "Python 3.8+, vLLM, PyTorch with CUDA, Triton"
+metadata:
+  version: "1.0.0"
+  author: flagos-ai
+  category: gpu-kernel-generation
+  tags: [kernelgen, vllm, triton, gpu, mcp, operator-generation]
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+# KernelGen Skill — Generate vLLM Operators via MCP
+
+You are an expert at generating GPU kernel operators for the vLLM project using the `kernelgen-mcp` MCP service.
+
+> **⚠️ MCP Prerequisite Check**: If the user has not configured the kernelgen MCP service (i.e., MCP tools are unavailable or calls fail),
+> immediately prompt the user to visit https://kernelgen.flagos.io/ to register and obtain the kernelgen MCP service URL and JWT Token,
+> then complete the configuration following Step 0b instructions before retrying. Do not proceed with subsequent steps if MCP is not ready.
+
+## Execution Rules
+
+Follow these rules strictly to avoid getting lost in the multi-step workflow:
+
+1. **Follow the steps in order**: Step 0 → Step 1 → Step 2 → ... → Step 8. Never jump ahead.
+2. **Never skip Step 2** (operator existence check) — always verify before generating.
+3. **Do not generate or write any code before Step 4** (MCP call). Steps 0–3 are preparation only.
+4. **Always confirm with the user before destructive actions**: replacing files, installing packages,
+   overwriting operators.
+5. **If any step fails, stop and report the error** to the user. Do not silently skip or retry
+   with different parameters.
+6. **Report progress to the user when entering each step**. Print a short status line like
+   `Entering Step 2 — checking whether the operator already exists...` so the user knows
+   the workflow is progressing and not stuck.
+7. **Never fabricate repository files or paths**. If a required file cannot be found using the
+   Glob or Grep tools, report it to the user instead of guessing. Do not assume a file exists
+   at a path without verifying it first.
+
+## Step 0: Pre-flight — Environment & MCP Check
+
+### 0a. Check Python Environment
+
+Use the Bash tool to run a diagnostic that checks each package independently (so one failure
+does not prevent checking the rest):
+
+```bash
+python - <<'PY'
+import importlib
+
+def check(pkg):
+    try:
+        m = importlib.import_module(pkg)
+        print(pkg, getattr(m, "__version__", "installed"))
+        return True
+    except Exception:
+        print(pkg, "NOT installed")
+        return False
+
+check("torch")
+triton_ok = check("triton")
+
+try:
+    import torch
+    print("cuda available", torch.cuda.is_available())
+    if torch.cuda.is_available():
+        print("torch.cuda version:", torch.version.cuda)
+        n = torch.cuda.device_count()
+        print("cuda devices:", n)
+        for i in range(n):
+            print(f"  cuda:{i}", torch.cuda.get_device_name(i))
+except Exception:
+    pass
+
+if triton_ok:
+    try:
+        import triton.runtime
+        print("triton runtime OK")
+    except Exception as e:
+        print("triton runtime issue:", e)
+
+check("vllm")
+check("pytest")
+check("numpy")
+
+try:
+    import subprocess
+    result = subprocess.run(["nvidia-smi"], capture_output=True, text=True, timeout=5)
+    if result.returncode == 0:
+        for line in result.stdout.splitlines()[:4]:
+            print(line)
+    else:
+        print("nvidia-smi: failed")
+except Exception:
+    print("nvidia-smi: not found")
+PY
+```
+
+**If any import fails**, stop and ask the user before installing anything. Present the missing
+packages and let the user confirm:
+
+| Missing package | Suggested install command | Notes |
+|---|---|---|
+| `torch` | `pip install torch --index-url https://download.pytorch.org/whl/cu121` | User MUST pick the correct CUDA variant (cu118/cu121/cu124). Ask which CUDA version they have. |
+| `triton` | `pip install triton` | |
+| `vllm` | `pip install -e .` (from repo root) | Confirm the current directory is the vLLM repo root first. |
+| `pytest` | `pip install pytest` | |
+| `numpy` | `pip install numpy` | |
+
+**Important**: Never install `torch` without asking the user which CUDA version they need.
+A wrong CUDA version will cause silent failures.
+
+If `torch` is installed but `torch.cuda.is_available() == False`, warn the user that GPU
+tests will fail and ask how to proceed before continuing.
+
+After the user confirms and packages are installed, re-run the diagnostic. Only proceed when
+all imports succeed.
+
+### 0b. Check MCP Availability
+
+Use the Read tool to read the file `.claude/settings.json` at the project root.
+If the file does not exist, the MCP is NOT configured.
+
+If the file exists, parse the JSON and check whether the exact key `"kernelgen-mcp"` exists
+under `mcpServers`:
+
+```
+mcpServers["kernelgen-mcp"]
+```
+
+- If the key `"kernelgen-mcp"` does **not** exist → the MCP is NOT configured.
+- If the key `"kernelgen-mcp"` **does** exist → the MCP IS configured — proceed to Step 1.
+
+Do NOT use substring matching (e.g., matching `"kernelgen"` inside `"my_kernelgen_server"`).
+Only the exact key `"kernelgen-mcp"` counts.
+
+**If the MCP server is NOT configured**, stop and tell the user:
+
+```
+kernelgen-mcp service is not configured. Please follow these steps:
+
+1. Visit https://kernelgen.flagos.io/ to register and obtain your JWT Token.
+2. Provide your MCP service URL and JWT Token to me, and I will help you write the configuration.
+
+   The final configuration format is as follows:
+   {
+     "mcpServers": {
+       "kernelgen-mcp": {
+         "type": "sse",
+         "url": "<YOUR_URL>",
+         "headers": {
+           "Authorization": "Bearer <YOUR_JWT_TOKEN>"
+         }
+       }
+     }
+   }
+```
+
+Wait for the user to provide the URL and JWT Token. Then:
+
+1. Use the Read tool to check if `.claude/settings.json` already exists.
+2. If it exists, read its content and parse the JSON. Then:
+   - If `mcpServers` key already exists, add `"kernelgen-mcp": {...}` into it **without
+     removing any other existing MCP server entries**.
+   - If `mcpServers` key does not exist, create it with the single `kernelgen-mcp` entry.
+   - **Never overwrite the entire file** — preserve all other top-level keys.
+3. If the file does not exist, create it with just the `mcpServers` object.
+4. Use the Write tool (for new file) or Edit tool (for existing file) to save.
+5. Tell the user to **restart Claude Code** so the new MCP server is picked up, then re-run
+   the `/kernelgen_for_vllm` command.
+
+**If the MCP server IS configured**, proceed to Step 1.
+
+## Step 1: Understand the Operator Request
+
+Parse the user's description to determine:
+- `kernel_name`: operator name (e.g., `rms_norm`, `silu_and_mul`, `rotary_embedding`, `paged_attention`)
+- `func_desc`: what the operator does
+- `func_type`: one of `activation`, `norm`, `attention`, `quantization`, `moe`, `sampling`, `other`.
+  **Auto-infer from the operator signature when possible:**
+  - If name contains `relu`, `gelu`, `silu`, `swish`, `tanh`, `sigmoid` → `activation`
+  - If name contains `norm`, `rmsnorm`, `layernorm`, `batchnorm` → `norm`
+  - If name contains `attention`, `flash`, `paged` → `attention`
+  - If name contains `quant`, `awq`, `gptq`, `squeezellm` → `quantization`
+  - If name contains `moe`, `expert` → `moe`
+  - If name contains `sample`, `top_k`, `top_p` → `sampling`
+  - If operator has >=2 tensor inputs → `binary_pointwise`
+  - Otherwise → `other`
+  Confirm the inferred `func_type` with the user if ambiguous.
+- `arg_names`, `arg_type`, `arg_descs`, `output_arg_desc`: parameter information
+
+**Normalize `kernel_name` to snake_case** before using it anywhere:
+- `RMSNorm` → `rms_norm`
+- `SiluAndMul` → `silu_and_mul`
+- `RMS-Norm` → `rms_norm`
+- `layerNorm` → `layer_norm`
+
+This ensures consistent file naming and codebase search in subsequent steps.
+
+Check this common alias table before asking the user:
+
+| User says | Correct `kernel_name` |
+|---|---|
+| swish | `silu` |
+| negative / negate | `neg` |
+| power | `pow` |
+| absolute | `abs` |
+| multiply | `mul` |
+| divide | `div` |
+| clip | `clamp` |
+| square | `pow` (exp=2) |
+| square_root | `sqrt` |
+| cube | `pow` (exp=3) |
+| cube_root | `cbrt` |
+| hard_swish | `hardswish` |
+| hard_sigmoid | `hardsigmoid` |
+
+If the alias is not in this table, ask the user to clarify.
+
+**Keep `kernel_name` concise** — ideally 30 characters or fewer. If the normalized name is
+too long (e.g., `fused_swiglu_layernorm_kernel`), suggest a shorter alias to the user (e.g.,
+`fused_swiglu_ln`). Long names create unwieldy file paths like
+`tests/kernels/test_fused_swiglu_layernorm_kernel.py`.
+
+**If argument information is missing or the description is vague** (e.g., "generate a fused swiglu kernel"):
+1. Use the Grep tool to search for the operator name across the repository, specifically in:
+   - `csrc/` — CUDA kernel implementations (function signatures)
+   - `vllm/model_executor/layers/` — Python layer wrappers (forward method signatures)
+   - `vllm/kernels/` — existing Triton kernels
+   - `vllm/_custom_ops.py` — custom op registrations (full function signatures)
+2. From the search results, infer the argument names, types, and descriptions.
+3. Present the inferred signature to the user for confirmation before proceeding.
+4. **Fallback**: If no matches are found in the codebase, use a generic tensor signature as
+   the starting point and ask the user to confirm or refine:
+   ```
+   arg_names: ["x"]
+   arg_type: ["torch.Tensor"]
+   arg_descs: ["Input tensor, typically shaped (num_tokens, hidden_size) for most vLLM kernels, or (num_heads, seq_len, head_dim) for attention/rope kernels"]
+   output_arg_desc: "Output tensor of same shape as input"
+   ```
+   Note: vLLM kernels almost always use `(num_tokens, hidden_size)` as the input shape
+   convention — NOT `(batch, seq_len, hidden)`. Use 2D shapes by default.
+5. If the operator is truly ambiguous even after presenting the fallback, stop and ask
+   the user to provide the full signature.
+
+## Step 2: Check Whether the Operator Already Exists
+
+Before calling the MCP generator, **thoroughly search** the codebase using the Glob and Grep tools:
+
+1. **Triton kernels**: Use `Glob("vllm/kernels/**/*<kernel_name>*")` to find Triton-based kernel files.
+2. **Triton kernels (alt)**: Use `Glob("vllm/triton_kernels/**/*<kernel_name>*")` — some kernels like rms_norm, silu_and_mul live here.
+3. **CUDA kernels**: Use `Glob("csrc/**/*<kernel_name>*")` to find CUDA kernel files.
+4. **Attention backends**: Use `Glob("vllm/attention/**/*<kernel_name>*")` — many attention/flash kernels live here.
+5. **Custom ops**: First use `Glob("vllm/**/*custom_op*")` to locate the actual custom op file
+   (commonly `vllm/_custom_ops.py` or `vllm/model_executor/custom_op.py`), then use Grep on
+   the found file(s) to check for the op name.
+6. **Model layers**: Use `Grep(pattern="<kernel_name>", path="vllm/model_executor/layers/")` for layer impls.
+7. **Tests**: Use `Glob("tests/kernels/*<kernel_name>*")` to find test files.
+8. **Benchmarks**: Use `Glob("benchmarks/kernels/*<kernel_name>*")` to find benchmark files.
+
+Also search for common aliases and naming variants:
+- Underscore vs concatenated: `rms_norm` vs `rmsnorm`, `silu_mul` vs `silu_and_mul`
+- CamelCase vs snake_case: `RMSNorm` vs `rms_norm`, `SiluAndMul` vs `silu_and_mul`
+- All-lowercase: `rmsnorm`, `layernorm`, `rotaryembedding`
+- **Partial name components**: for compound names like `silu_and_mul`, also search for `silu`
+  and `mul` individually — the kernel may live inside a file with a different name (e.g.,
+  `activation.py` contains `silu_and_mul`).
+
+### If the operator already exists
+
+Present the findings to the user and ask them to choose one of the following. Stop and wait
+for the user to respond before continuing:
+
+> The operator `<kernel_name>` already exists in the codebase:
+> - Implementation: `<file path>`
+> - Tests: `<file path>`
+> - Benchmarks: `<file path>`
+>
+> Please choose how to proceed:
+>
+> **A — Skip generation**: The operator already exists; do nothing.
+>
+> **B — Replace existing**: Overwrite the current implementation with MCP-generated code.
+>
+> **C — Create a custom variant (side-by-side)**: Generate as `<kernel_name>_v2` alongside
+> the original, without overriding the existing dispatch.
+
+Only proceed to Step 3 after the user has made a choice.
+
+### If the operator does NOT exist
+
+Proceed directly to Step 3.
+
+## Step 3: Research Context (flagos_wiki)
+
+Before calling the MCP generator, use the Read tool to gather reference materials. This improves
+generation quality significantly.
+
+1. **Read similar operator code** from the codebase:
+   - Activation op → read `csrc/activation_kernels.cu` or `vllm/model_executor/layers/activation.py`
+   - Norm op → read `csrc/layernorm_kernels.cu` or `vllm/model_executor/layers/layernorm.py`
+   - Attention op → read files under `csrc/attention/` or `vllm/attention/`
+   - Quantization op → read files under `csrc/quantization/`
+   - MoE op → read files under `csrc/moe/` or `vllm/model_executor/layers/fused_moe/`
+
+2. **Read the test pattern** from the matching test file to understand shapes, dtypes, assertions.
+
+3. **Read the benchmark pattern** from the matching benchmark file to understand timing methodology.
+
+4. **If replacing an existing op** (Option B), read the current implementation so the new version
+   can be compared / improved upon.
+
+   **If reference files cannot be found or the Read tool fails**, do not stop. Proceed with
+   general algorithm hints based on your knowledge of the operator type instead. An empty or
+   minimal `flagos_wiki` is acceptable — it is better to continue than to block the workflow.
+
+5. Collect all findings into the `flagos_wiki` parameter as a `List[str]`. Rules:
+   - Each string should be a concise reference snippet, **under 200 characters** (not tokens).
+   - **Maximum 10 items** — avoid token explosion.
+   - **Prefer algorithm insights over file path descriptions** — the MCP generator benefits
+     more from understanding *how* an algorithm works than *where* a file lives.
+   - Avoid redundant items — do not repeat the same concept in different words (e.g., "block
+     reduction", "shared memory reduction", "warp reduction" are all the same idea).
+   - **Always include a kernel pattern hint** as the first item — this helps the MCP choose
+     the right code structure. The first item **MUST** start with the literal prefix
+     `"Kernel pattern: "` followed by one of: `elementwise`, `row-wise`, `reduction`,
+     `matmul-like`, `fused-multi-op`. Example: `"Kernel pattern: row-wise reduction over hidden_size"`.
+     Do not use alternative prefixes like `"Pattern:"` or `"Type:"` — the MCP parser expects
+     exactly `"Kernel pattern: "`.
+   - **Always include a memory layout hint**: `"Input tensors are contiguous row-major layout"`
+     — this reduces Triton miscompile risk for strided inputs.
+
+```python
+flagos_wiki = [
+    # GOOD: algorithm insights
+    "Layernorm uses Welford online algorithm for numerically stable variance computation",
+    "Block reduction via shared memory with warp-level shuffle for final reduction step",
+    "Vectorized loads using float4 for memory bandwidth optimization",
+    "RMSNorm computes 1/sqrt(mean(x^2) + eps) * x, no mean subtraction unlike LayerNorm",
+    # OK: structural hints when relevant
+    "Test parametrizes over NUM_TOKENS=[1,17,86,1234,3045] and HIDDEN_SIZES=[16,48,128,1562,4096]",
+    "Benchmark uses triton.testing.do_bench_cudagraph with quantiles=[0.5, 0.2, 0.8]",
+    # BAD (avoid): bare file paths with no insight
+    # "File: csrc/layernorm_kernels.cu"
+]
+```
+
+## Step 4: Call kernelgen-mcp
+
+Invoke `mcp__kernelgen-mcp__generate_operator` with the parameters gathered above:
+
+```
+kernel_name:  "<kernel_name>"
+func_desc:    "<description of what the operator does>"
+func_type:    "<activation|norm|attention|quantization|moe|sampling|other>"
+arg_names:    [<list of argument names>]
+arg_type:     [<list of argument types>]
+arg_descs:    [<list of argument descriptions>]
+output_arg_desc: "<description of the output>"
+flagos_wiki:     [<list of reference strings from Step 3>]
+```
+
+The MCP returns code blocks which may include:
+- `torch_code` — PyTorch reference implementation
+- `triton_code` — Triton kernel implementation
+- `test_func_code` — accuracy test code
+- `benchmark_func_code` — performance benchmark code
+
+**If `torch_code` is missing from the MCP response**, construct a `ref_impl` yourself using
+standard PyTorch operations based on `func_desc`. For example, for `rms_norm`:
+```python
+def ref_impl(x, weight, eps=1e-6):
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps) * weight
+```
+This is needed so that accuracy tests have a reference to compare against.
+
+## Step 5: Adapt and Place Code into the vLLM Project
+
+This is the most critical step. The generated code must be transformed to match vLLM conventions.
+The exact placement depends on the operator type and the user's choice in Step 2.
+
+---
+
+### Path 1: New operator / Replace existing (Option B or new op)
+
+#### 5a. Determine the Correct Location
+
+Based on operator type, place the code in the appropriate location:
+
+| Operator Type | Triton Kernel Location | Layer Wrapper Location | CUDA Alternative |
+|---|---|---|---|
+| Activation | `vllm/kernels/` or inline in layer | `vllm/model_executor/layers/activation.py` | `csrc/activation_kernels.cu` |
+| Normalization | `vllm/kernels/` or inline in layer | `vllm/model_executor/layers/layernorm.py` | `csrc/layernorm_kernels.cu` |
+| Attention | `vllm/attention/backends/` | `vllm/attention/layer.py` | `csrc/attention/` |
+| Quantization | `vllm/kernels/` | `vllm/model_executor/layers/quantization/` | `csrc/quantization/` |
+| MoE | `vllm/kernels/` | `vllm/model_executor/layers/fused_moe/` | `csrc/moe/` |
+| Position Encoding | `vllm/kernels/` | `vllm/model_executor/layers/rotary_embedding.py` | `csrc/pos_encoding_kernels.cu` |
+| Cache | `vllm/kernels/` | N/A | `csrc/cache_kernels.cu` |
+| Sampling | `vllm/kernels/` | `vllm/model_executor/layers/sampler.py` | `csrc/sampler.cu` |
+| Other | `vllm/kernels/<kernel_name>.py` | As needed | As needed |
+
+#### 5b. Transform the Triton Kernel Code
+
+Adapt the MCP-generated Triton code to follow vLLM conventions:
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+import triton
+import triton.language as tl
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 64}, num_warps=2),
+        triton.Config({"BLOCK_SIZE": 128}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 256}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 512}, num_warps=8),
+    ],
+    # Choose autotune key based on kernel pattern:
+    #   elementwise → key=["n_elements"]
+    #   row-wise (layernorm, softmax) → key=["hidden_size"] or ["n_cols"]
+    # IMPORTANT: the key MUST match an existing non-pointer, non-constexpr
+    # kernel argument name. If the key does not exist in the kernel signature,
+    # Triton will raise a KeyError at compile time.
+    key=["n_elements"],  # ← replace with the actual problem-size arg name
+)
+@triton.jit
+def _<kernel_name>_kernel(
+    # pointer args
+    input_ptr,
+    output_ptr,
+    # dimensions
+    n_elements,
+    # meta parameters
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(input_ptr + offsets, mask=mask)
+    # kernel logic here
+    output = x  # placeholder
+    tl.store(output_ptr + offsets, output, mask=mask)
+
+
+def <kernel_name>(x: torch.Tensor) -> torch.Tensor:
+    """Python wrapper for the Triton kernel."""
+    assert x.is_cuda, "Input tensor must be on CUDA device"
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    output = torch.empty_like(x)
+    n_elements = x.numel()
+
+    def grid(meta):
+        return (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    _<kernel_name>_kernel[grid](
+        x, output, n_elements,
+    )
+    return output
+```
+
+**Important**: The example above is an **elementwise** kernel pattern. For **row-wise** kernels
+(layernorm, softmax, rmsnorm), the grid and indexing are different:
+
+```python
+def <kernel_name>(x: torch.Tensor, ...) -> torch.Tensor:
+    assert x.is_cuda and x.is_contiguous()
+    output = torch.empty_like(x)
+    num_rows, hidden_size = x.shape
+
+    # Row-wise: one program per row, each processes hidden_size elements
+    grid = (num_rows,)
+
+    _<kernel_name>_kernel[grid](
+        x, output, hidden_size,
+        # BLOCK_SIZE is autotuned via @triton.autotune
+    )
+    return output
+```
+
+**Choose the correct pattern based on kernel type:**
+- `activation` (elementwise): `grid = (triton.cdiv(n_elements, BLOCK_SIZE),)` — one program per block of elements
+- `norm` / `softmax` (row-wise): `grid = (num_rows,)` — one program per row
+- `attention` / `moe`: typically custom 2D/3D grids — follow MCP output
+- Always include `SPDX-License-Identifier: Apache-2.0` and copyright header
+- Use `vllm.logger.init_logger(__name__)` for logging
+- Kernel function names start with `_` and end with `_kernel`
+- Public wrapper function has a clean Python signature; use `x` (not `input`) as the tensor
+  parameter name to match vLLM convention and avoid shadowing Python's built-in `input()`
+- Use `torch.empty_like` or explicit allocation for outputs
+- Use `triton.cdiv` for grid computation
+- Use `tl.constexpr` for meta parameters like `BLOCK_SIZE`
+- **Use `@triton.autotune`** with power-of-two block sizes (64, 128, 256, 512) instead of
+  hardcoding a single BLOCK_SIZE. Avoid 1024 by default (register spill risk). Omit autotune
+  only for very simple kernels where a fixed block size is clearly optimal.
+- **Choose the correct autotune `key`**: use the main problem-size dimension that the launch grid
+  depends on. For elementwise kernels use `key=["n_elements"]`, for row-wise kernels (e.g.,
+  layernorm, softmax) use `key=["hidden_size"]` or `key=["n_cols"]`. The key must be a
+  non-pointer, non-constexpr parameter of the kernel.
+
+#### 5c. Register the Operator (if applicable)
+
+If the kernel needs to be callable via `vllm._custom_ops`:
+
+1. Use the Edit tool to add a Python wrapper function in `vllm/_custom_ops.py` (or the project's
+   actual custom op registration file if the path differs — verify with Glob first) that calls
+   the Triton kernel.
+2. If wrapping as a layer, use the Edit tool to add or modify the appropriate file under
+   `vllm/model_executor/layers/`.
+
+For Triton kernels that don't need custom op registration (standalone usage), just ensure
+the module is importable from `vllm.kernels.<kernel_name>`.
+
+#### 5d. Accuracy Test → `tests/kernels/test_<kernel_name>.py`
+
+Use the Write tool to create a test file following vLLM test conventions:
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+
+DTYPES = [torch.float16, torch.bfloat16, torch.float32]
+NUM_TOKENS = [1, 17, 128, 1024]
+HIDDEN_SIZES = [128, 512, 1024, 4096]
+SEEDS = [0]
+if not torch.cuda.is_available():
+    pytest.skip("CUDA not available", allow_module_level=True)
+
+CUDA_DEVICES = [f"cuda:{i}" for i in range(torch.cuda.device_count())]
+
+# Tolerance per dtype — fp16/bf16 need looser tolerances to avoid flaky CI
+TOLERANCES = {
+    torch.float32: {"rtol": 1e-5, "atol": 1e-5},
+    torch.float16: {"rtol": 1e-2, "atol": 1e-2},
+    torch.bfloat16: {"rtol": 2e-2, "atol": 2e-2},
+}
+
+
+def ref_impl(x: torch.Tensor) -> torch.Tensor:
+    """Reference PyTorch implementation.
+
+    This function uses pure PyTorch ops to compute the expected output.
+    It is used as ground truth for accuracy comparison.
+    """
+    # Use the torch_code from MCP as reference
+    ...
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@torch.inference_mode()
+def test_<kernel_name>(
+    num_tokens: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    torch.random.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+
+    ref_out = ref_impl(x)
+
+    from vllm.kernels.<kernel_name> import <kernel_name> as kernel_fn
+    act_out = kernel_fn(x)
+
+    tol = TOLERANCES[dtype]
+    torch.testing.assert_close(act_out, ref_out, rtol=tol["rtol"], atol=tol["atol"])
+```
+
+Key conventions:
+- Always include the SPDX license header
+- Use `@torch.inference_mode()` decorator
+- Parametrize with `DTYPES`, `NUM_TOKENS`, `HIDDEN_SIZES`, `SEEDS`, `CUDA_DEVICES`
+- Use `torch.testing.assert_close` for comparison
+- **Use per-dtype tolerances**: fp32 can use 1e-5, but fp16/bf16 need 1e-2 to avoid false failures
+- Provide `ref_impl` using **pure PyTorch ops** (from MCP's `torch_code`) — not `torch.<op>` which
+  may not exist for custom fused kernels
+- Use `torch.random.manual_seed` for reproducibility; guard `torch.cuda.manual_seed` with
+  `if torch.cuda.is_available()` to avoid crash on CPU-only environments
+
+#### 5e. Performance Benchmark → `benchmarks/kernels/benchmark_<kernel_name>.py`
+
+Use the Write tool to create a benchmark file following vLLM benchmark conventions:
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import itertools
+
+import torch
+
+if not torch.cuda.is_available():
+    raise RuntimeError("CUDA is required to run this benchmark")
+
+import triton
+import triton.testing
+
+from vllm.utils.torch_utils import set_random_seed
+
+batch_size_range = [1, 16]
+seq_len_range = [1, 64, 1024]
+hidden_size_range = [1024, 4096]
+# 2 * 3 * 2 = 12 configs — keeps benchmark under 2 minutes
+configs = list(itertools.product(batch_size_range, seq_len_range, hidden_size_range))
+
+
+def ref_impl(x: torch.Tensor) -> torch.Tensor:
+    """Reference PyTorch implementation (same as in the test file).
+
+    Used as the baseline for performance comparison.
+    """
+    # Paste the same ref_impl from the test file
+    ...
+
+
+def benchmark_<kernel_name>(
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    provider: str,
+    dtype: torch.dtype,
+):
+    device = torch.device("cuda")
+    num_tokens = batch_size * seq_len
+    set_random_seed(42)
+
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device).contiguous()
+
+    from vllm.kernels.<kernel_name> import <kernel_name> as kernel_fn
+
+    # Warmup — compile Triton kernel and stabilize GPU clocks before benchmarking
+    for _ in range(5):
+        kernel_fn(x)
+    torch.cuda.synchronize()
+
+    if provider == "triton":
+        fn = lambda: kernel_fn(x)
+    elif provider == "torch":
+        fn = lambda: ref_impl(x)
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
+        fn, quantiles=[0.5, 0.2, 0.8]
+    )
+    return ms, min_ms, max_ms
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["batch_size", "seq_len", "hidden_size"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=["triton", "torch"],
+        line_names=["Triton Kernel", "PyTorch Reference"],
+        styles=[("blue", "-"), ("green", "-")],
+        ylabel="Time (ms)",
+        plot_name="<kernel_name>-benchmark",
+        # float16 is the default because Triton kernels are typically optimized for fp16 inference
+        args={"dtype": torch.float16},
+    )
+)
+def bench_<kernel_name>(batch_size, seq_len, hidden_size, provider, dtype):
+    return benchmark_<kernel_name>(batch_size, seq_len, hidden_size, provider, dtype)
+
+
+if __name__ == "__main__":
+    bench_<kernel_name>.run(print_data=True)
+```
+
+Key conventions:
+- Use `import triton; import triton.testing` directly (not `vllm.triton_utils`) for benchmarks,
+  as `vllm.triton_utils` may not export `triton.testing` in all versions
+- Use `triton.testing.do_bench_cudagraph` for accurate GPU timing
+- Use `triton.testing.perf_report` and `triton.testing.Benchmark` for structured output
+- **Always use `ref_impl` for the torch baseline**, never `torch.<op>` — many custom/fused
+  kernels have no single torch equivalent
+- Parametrize across batch sizes, sequence lengths, and hidden sizes
+- Use `set_random_seed` for reproducibility
+
+---
+
+### Path 2: Custom variant side-by-side (Option C)
+
+#### 5a. Operator Implementation → `vllm/kernels/<kernel_name>_v2.py`
+
+Use the Write tool to create the file. Use the **raw Triton pointer-based style** for the kernel.
+Keep the MCP-generated Triton code mostly as-is but ensure it:
+- Has the SPDX license header
+- Is self-contained (minimal vLLM imports)
+- Has proper `@triton.jit` kernel with pointer args, mask, and autotuned BLOCK_SIZE
+- Exports a clean Python wrapper function named `<kernel_name>_v2`
+
+#### 5b. Registration (limited)
+
+Do **NOT** register the variant in `vllm/_custom_ops.py` — it must NOT override the existing
+operator. The variant should be importable directly from `vllm.kernels.<kernel_name>_v2`.
+
+#### 5c. Standalone Test → `tests/kernels/test_<kernel_name>_v2.py`
+
+Use the Write tool to create a self-contained test file:
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.kernels.<kernel_name>_v2 import <kernel_name>_v2 as kernel_fn
+
+
+DTYPES = [torch.float16, torch.bfloat16, torch.float32]
+SHAPES = [(1, 128), (16, 512), (128, 1024), (1024, 4096)]
+SEEDS = [0]
+
+TOLERANCES = {
+    torch.float32: {"rtol": 1e-5, "atol": 1e-5},
+    torch.float16: {"rtol": 1e-2, "atol": 1e-2},
+    torch.bfloat16: {"rtol": 2e-2, "atol": 2e-2},
+}
+
+
+def ref_impl(x: torch.Tensor) -> torch.Tensor:
+    """Reference PyTorch implementation."""
+    ...
+
+
+@pytest.mark.parametrize("shape", SHAPES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@torch.inference_mode()
+def test_<kernel_name>_v2_accuracy(shape, dtype, seed):
+    torch.random.manual_seed(seed)
+    x = torch.randn(shape, dtype=dtype, device="cuda")
+    ref_out = ref_impl(x)
+    act_out = kernel_fn(x)
+    tol = TOLERANCES[dtype]
+    torch.testing.assert_close(act_out, ref_out, rtol=tol["rtol"], atol=tol["atol"])
+```
+
+#### 5d. Standalone Benchmark → `benchmarks/kernels/benchmark_<kernel_name>_v2.py`
+
+Use the Write tool to create a self-contained benchmark file following the same pattern as
+Path 1 Section 5e, but importing from `vllm.kernels.<kernel_name>_v2` and using `ref_impl`
+as the torch baseline.
+
+---
+
+## Step 6: Run Accuracy Tests
+
+Use the Bash tool to run the accuracy tests for the newly added operator.
+
+First, verify the working directory is the vLLM repo root:
+```bash
+pwd
+```
+If the output is NOT the vLLM repo root (should contain `vllm/`, `csrc/`, `tests/`), stop
+and ask the user for the correct path.
+
+Then run with `PYTHONPATH=.` to ensure vllm is importable even if not pip-installed.
+
+**First, do a quick smoke test** to catch Triton compilation errors before running the full
+pytest suite (which produces messy output on compilation failures):
+
+```bash
+PYTHONPATH=. python -c "
+from vllm.kernels.<kernel_name> import <kernel_name> as fn
+import torch
+x = torch.randn(4, 128, dtype=torch.float16, device='cuda')
+# If kernel requires extra arguments (e.g. weight, bias, eps for norm kernels),
+# create matching dummy tensors:
+#   weight = torch.ones(128, dtype=torch.float16, device='cuda')
+#   out = fn(x, weight, eps=1e-6)
+out = fn(x)
+print('Smoke test passed, output shape:', out.shape)
+"
+```
+
+If this fails with `triton.compiler.CompilationError` or `ImportError`, fix the kernel code
+first — do not proceed to pytest. **Adapt the smoke test arguments to match the kernel's
+actual signature** — if the kernel requires `weight`, `bias`, `eps`, or other parameters,
+create appropriate dummy tensors or scalar values. Use `inspect.signature` to infer missing
+arguments (e.g., `weight`, `bias`, `eps` for `layer_norm`) before constructing the smoke test.
+
+**If smoke test passes, run the full test suite:**
+
+**For Path 1 (new / replace):**
+```bash
+PYTHONPATH=. python -m pytest tests/kernels/test_<kernel_name>.py -v
+```
+
+**For Path 2 (custom variant):**
+```bash
+PYTHONPATH=. python -m pytest tests/kernels/test_<kernel_name>_v2.py -v
+```
+
+Report the results to the user. If tests fail, follow the **error classification and retry
+protocol** below. This protocol strictly limits self-fix attempts to prevent infinite loops.
+
+### Error Classification
+
+First, classify the error into one of two categories:
+
+**Category A — Compilation / Import errors** (model may attempt 1 self-fix):
+- `ImportError`, `ModuleNotFoundError` — wrong import path or missing module
+- `SyntaxError` — Python syntax issue
+- `TritonCompilationError`, `CompilationError` — Triton kernel compile failure
+- `NameError` — undefined variable or function
+- `TypeError` in function call signature — wrong number/type of arguments
+- `AttributeError` — wrong attribute access on a module or object
+
+**Category B — Algorithm / Numerical accuracy errors** (do NOT self-fix):
+- `AssertionError` from `torch.testing.assert_close` — numerical mismatch
+- Wrong output values (results don't match reference)
+- Shape mismatch in output tensors
+- NaN or Inf in output
+- Any error that indicates the kernel logic is incorrect
+
+### Retry Protocol (strictly follow this order)
+
+**Step 6a. (Category A only) Self-fix — maximum 1 attempt:**
+If the error is Category A (compilation/import), you may attempt exactly ONE fix:
+1. Read the error traceback carefully.
+2. Apply a targeted fix using the Edit tool (e.g., fix import path, fix syntax, fix argument name).
+3. Re-run the tests using the Bash tool.
+4. If the test **passes** → proceed to Step 7.
+5. If the test **still fails** → proceed to Step 6b. Do NOT attempt a second self-fix.
+
+**If the error is Category B (algorithm/accuracy), skip Step 6a entirely** — go directly
+to Step 6b. Do NOT attempt to fix algorithm logic yourself, as this typically leads to
+an endless fix-retry loop without converging. The MCP service has better optimization
+capabilities for these issues.
+
+**Step 6b. MCP re-generation — pass error context to generate_operator:**
+Re-call `mcp__kernelgen-mcp__generate_operator` with the **same parameters as Step 4**,
+but add the error information to `flagos_wiki` as additional hints:
+```python
+flagos_wiki = [
+    # ... original flagos_wiki items from Step 3 ...
+    "Previous generation failed accuracy test: <brief error description>",
+    "Error was: <key line from traceback, e.g. 'AssertionError: values differ at index 42'>",
+    "Fix hint: <your analysis, e.g. 'epsilon not applied before rsqrt'>"
+]
+```
+Replace the kernel code with the new MCP output, re-run tests.
+- If tests **pass** → proceed to Step 7.
+- If tests **still fail** → proceed to Step 6c.
+
+**Step 6c. MCP optimization — pass error context to optimize_triton:**
+Try `mcp__kernelgen-mcp__optimize_triton` with the current kernel code and the
+`check_result` parameter containing the error traceback. This endpoint can fix
+memory access patterns, index calculations, and numerical issues.
+Replace the kernel code with the optimized output, re-run tests.
+- If tests **pass** → proceed to Step 7.
+- If tests **still fail** → proceed to Step 6d.
+
+**Step 6d. Stop and report:**
+Do not keep retrying. Report the failure to the user with:
+- The specific test failures and error messages
+- Your analysis of what might be wrong
+- Suggestion to try with different `func_type` or additional `flagos_wiki` hints
+
+## Step 7: Run Performance Benchmark
+
+Use the Bash tool to run the benchmark with `PYTHONPATH=.`:
+
+**For Path 1 (new / replace):**
+```bash
+PYTHONPATH=. python benchmarks/kernels/benchmark_<kernel_name>.py
+```
+
+**For Path 2 (custom variant):**
+```bash
+PYTHONPATH=. python benchmarks/kernels/benchmark_<kernel_name>_v2.py
+```
+
+Report the speedup results to the user.
+
+## Step 8: Summary
+
+Provide a clear summary to the user with **exact numbers** extracted from test and benchmark
+output:
+
+```
+=== KernelGen Operator Generation Report ===
+
+Operator Name: <kernel_name>
+Generation Mode: New / Replace Existing / Custom Variant (v2)
+
+File Changes:
+  - [New/Modified] vllm/kernels/<kernel_name>.py          (Triton kernel)
+  - [Modified] vllm/_custom_ops.py                          (op registration, if applicable)
+  - [Modified] vllm/model_executor/layers/<layer_file>.py   (layer wrapper, if applicable)
+  - [New/Modified] tests/kernels/test_<kernel_name>.py     (accuracy test)
+  - [New/Modified] benchmarks/kernels/benchmark_<kernel_name>.py (benchmark)
+
+Accuracy Tests: <N> passed, <M> failed (total <N+M> test cases)
+  Pass Rate: <N/(N+M)*100>%
+  Failed Cases: <list failed test names if any, or "None">
+
+Performance Benchmark:
+  Avg Speedup: <X.XX>x vs PyTorch reference
+  Best Speedup: <X.XX>x (batch_size=<B>, seq_len=<S>, hidden_size=<H>)
+  Worst Speedup: <X.XX>x (batch_size=<B>, seq_len=<S>, hidden_size=<H>)
+  (If benchmark was not run or failed, write "Incomplete" and explain why)
+
+MCP Iterations: <1, 2, or 3> (write 1 if first generation passed)
+
+Performance Analysis:
+  <Assess based on average speedup:
+   - Speedup > 5.0x → "Extreme fusion success, typical for fused multi-op kernels (e.g. fused SwiGLU, fused GeLU+bias)"
+   - Speedup > 3.0x → "Excellent compute-bound optimization, significant kernel fusion benefit"
+   - Speedup > 2.0x → "Compute-bound optimization effective, significant speedup achieved"
+   - Speedup 1.2x ~ 2.0x → "Moderate speedup, kernel likely balanced between compute and memory"
+   - Speedup 0.5x ~ 1.2x → "Kernel likely memory-bound, limited optimization headroom"
+   - Speedup < 0.5x → "Kernel slower than PyTorch reference — likely suboptimal memory access pattern">
+
+Issues and Fixes: (if any)
+```
+
+**After presenting the summary, check the speedup:**
+
+- **If average speedup < 0.5x** (kernel slower than PyTorch), proactively warn the user:
+  ```
+  ⚠️ The generated Triton kernel is slower than the PyTorch reference implementation.
+  This is typically caused by suboptimal memory access patterns or improper block size configuration.
+  Would you like to use /kernelgen_optimizer to optimize this kernel's performance?
+  ```
+
+- **If average speedup is 0.5x ~ 1.2x**, ask the user:
+  ```
+  Current speedup is low (<X.XX>x), there may be room for optimization.
+  Would you like to use /kernelgen_optimizer to try improving performance?
+  ```
+
+- **If average speedup > 1.2x**, no action needed — report the result normally.
+
+**How to extract the numbers:**
+- **Pass/fail counts**: Parse pytest output for the line matching `X passed` or `X passed, Y failed`.
+  Use regex pattern `(\d+) passed` and `(\d+) failed` to extract.
+- **Speedup**: The benchmark outputs a table with columns for each provider. For each config row:
+  1. Find the `Triton Kernel` time (ms) and `PyTorch Reference` time (ms)
+  2. Calculate `speedup = torch_time / triton_time`
+  3. Compute min, max, and average across all config rows
+  - If the output format is not a table, look for lines containing `provider=triton` and
+    `provider=torch` with time values, and compute the ratio.
+  - Use these regex patterns to extract timing values:
+    - `(\d+(?:\.\d+)?)\s*(us|ms|s)` — number with unit
+    - `(?i)mean:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — mean timing (pytest-benchmark format)
+    - `(?i)avg:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — average timing
+    - `(?i)median:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — median timing value
+    - `(?i)Triton.*?(\d+(?:\.\d+)?)\s*(us|ms|s)` — Triton kernel time
+    - `(?i)(torch|pytorch).*?(\d+(?:\.\d+)?)\s*(us|ms|s)` — PyTorch reference time
+  - **Do not just copy the raw table** — always compute and report the actual speedup ratios.
+
+## Important Notes
+
+- **Never overwrite existing operators** without explicit user permission (Step 2 choice).
+- **Always ask the user before installing packages** — never run `pip install` without confirmation.
+- **Follow vLLM code style** exactly: SPDX headers, logging via `init_logger`, type hints.
+- **Use explicit tools for all file operations**: Read tool to read files, **Write tool to create
+  new files** (only when the file does not exist), **Edit tool to modify existing files** (never
+  use Write to overwrite an existing file — use Edit to apply targeted changes), Glob tool to
+  find files, Grep tool to search content, Bash tool to run commands.
+- **Use `@triton.autotune`** with multiple power-of-two BLOCK_SIZE configs (64/128/256/512)
+  instead of hardcoding a single value. Include 64 for small hidden sizes (e.g., 96, 192).
+  Avoid 1024 by default as it risks register spill on complex kernels — only add it if the
+  kernel is very simple (e.g., elementwise with no shared state).
+- **Use per-dtype tolerances** in tests: fp32 → rtol/atol=1e-5, fp16 → 1e-2, bf16 → 2e-2.
+  For complex kernels (layernorm, softmax, attention) consider even looser bf16 tolerances (3e-2)
+  if CI is flaky.
+- **Always use `ref_impl` for benchmarks**, not `torch.<op>` — many custom/fused kernels have
+  no single torch equivalent function.
+- **Match the existing code patterns** when adding to existing files (e.g., `_custom_ops.py`, layer files).
+- If accuracy tests fail, try to fix the operator. If benchmark is slow, consider calling
+  `mcp__kernelgen-mcp__optimize_triton` to optimize the kernel.
+- When creating a custom variant, always make it clear that it does NOT override existing ops
+  to avoid conflicts.
+- **Always use `@torch.inference_mode()`** in tests for consistency with the codebase.
+- **Use `import triton; import triton.testing`** directly in benchmarks. Do not use
+  `vllm.triton_utils.triton` as it may not export `triton.testing` in all versions.
+- If the generated kernel is a CUDA kernel (not Triton), place it in `csrc/` and add bindings
+  in `csrc/torch_bindings.cpp` and `csrc/ops.h` — but prefer Triton when possible.
+- Check if the kernel needs to be registered in `vllm/model_executor/custom_op.py` if it's
+  an activation or layer-level op that should participate in the custom op dispatch system.
+- **Never modify unrelated files** in the repository. Do not reformat imports, fix lint, or
+  make stylistic changes to files that are not directly part of the operator being generated.
+  Keep the diff minimal and focused.

--- a/skills/kernelgen-submit-feedback/LICENSE.txt
+++ b/skills/kernelgen-submit-feedback/LICENSE.txt
@@ -1,0 +1,200 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get an
+      OpenPGP-compatible signature of your completed statement.
+
+   Copyright 2026 BAAI (Beijing Academy of Artificial Intelligence)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/kernelgen-submit-feedback/README.md
+++ b/skills/kernelgen-submit-feedback/README.md
@@ -1,0 +1,79 @@
+# kernelgen-submit-feedback: Skill Feedback Submission
+
+[中文版](README_zh.md)
+
+## Overview
+
+`kernelgen-submit-feedback` is an AI coding skill that helps users submit bug reports, defect reports, and improvement suggestions for skills in the FlagOS skills repository.
+
+### Problem Statement
+
+When users encounter bugs or have suggestions for skills, they need to gather environment information, format the report properly, and submit it through the right channel. This process is tedious and often results in incomplete bug reports missing critical environment details.
+
+This skill automates the entire feedback workflow: **gather information → auto-collect environment → verify GitHub CLI → construct issue → submit**, with an automatic email fallback when GitHub CLI is unavailable.
+
+### Usage
+
+```bash
+# Submit feedback interactively
+/kernelgen-submit-feedback
+
+# Submit feedback for a specific skill
+/kernelgen-submit-feedback kernelgen
+```
+
+| Argument | Required | Default | Description |
+|---|---|---|---|
+| `skill-name` | No | Inferred from context | Name of the skill the feedback is about |
+
+---
+
+## Submission Workflow
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Step 1   Determine submission method (GitHub or Email)  │
+│  Step 2   Gather information from user                   │
+│  Step 3   Auto-collect environment information           │
+│  Step 4   Verify GitHub CLI availability                 │
+│  Step 5   Determine issue type and labels                │
+│  Step 6   Construct the issue                            │
+│  Step 7   Confirm with user                              │
+│  Step 8   Submit the issue                               │
+│  Step 9   Confirm creation                               │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Key Features
+
+- **Auto environment detection** — automatically collects OS, Python, PyTorch, CUDA, and Triton versions
+- **GitHub CLI integration** — submits issues directly via `gh issue create`
+- **Email fallback** — generates email draft with mailto link when GitHub CLI is unavailable
+- **Smart context reuse** — extracts information from conversation history instead of re-asking
+- **Label management** — verifies label existence before submission to avoid errors
+
+---
+
+## Directory Structure
+
+```
+skills/kernelgen-submit-feedback/
+├── SKILL.md        # Skill definition (entry point)
+├── LICENSE.txt     # Apache 2.0 license
+├── README.md       # This document (English)
+└── README_zh.md    # Chinese version
+```
+
+---
+
+## Related Skills
+
+- [`kernelgen`](../kernelgen/) — General purpose GPU kernel generation
+- [`kernelgen-for-flaggems`](../kernelgen-for-flaggems/) — FlagGems-specific kernel generation
+- [`kernelgen-for-vllm`](../kernelgen-for-vllm/) — vLLM-specific kernel generation
+
+---
+
+## License
+
+This project is licensed under the Apache 2.0 License. See [LICENSE.txt](LICENSE.txt) for details.

--- a/skills/kernelgen-submit-feedback/README_zh.md
+++ b/skills/kernelgen-submit-feedback/README_zh.md
@@ -1,0 +1,77 @@
+# kernelgen-submit-feedback：技能反馈提交
+
+## 概述
+
+`kernelgen-submit-feedback` 是一个 AI 编程技能，帮助用户为 FlagOS skills 仓库中的技能提交 bug 报告、缺陷报告和改进建议。
+
+### 解决的问题
+
+当用户遇到 bug 或有改进建议时，需要收集环境信息、正确格式化报告并通过正确的渠道提交。这个过程很繁琐，经常导致 bug 报告不完整，缺少关键的环境详情。
+
+本技能自动化了整个反馈工作流程：**收集信息 → 自动采集环境 → 验证 GitHub CLI → 构建 issue → 提交**，当 GitHub CLI 不可用时自动回退到邮件方式。
+
+### 使用方式
+
+```bash
+# 交互式提交反馈
+/kernelgen-submit-feedback
+
+# 为特定技能提交反馈
+/kernelgen-submit-feedback kernelgen
+```
+
+| 参数 | 必填 | 默认值 | 说明 |
+|---|---|---|---|
+| `skill-name` | 否 | 从上下文推断 | 反馈所针对的技能名称 |
+
+---
+
+## 提交工作流
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  步骤 1   确定提交方式（GitHub 或邮件）                    │
+│  步骤 2   从用户收集信息                                   │
+│  步骤 3   自动采集环境信息                                 │
+│  步骤 4   验证 GitHub CLI 可用性                           │
+│  步骤 5   确定 issue 类型和标签                            │
+│  步骤 6   构建 issue                                      │
+│  步骤 7   与用户确认                                       │
+│  步骤 8   提交 issue                                      │
+│  步骤 9   确认创建                                        │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 核心特性
+
+- **自动环境检测** — 自动收集 OS、Python、PyTorch、CUDA 和 Triton 版本信息
+- **GitHub CLI 集成** — 通过 `gh issue create` 直接提交 issue
+- **邮件回退** — 当 GitHub CLI 不可用时生成邮件草稿和 mailto 链接
+- **智能上下文复用** — 从对话历史中提取信息，避免重复询问
+- **标签管理** — 提交前验证标签是否存在，避免错误
+
+---
+
+## 目录结构
+
+```
+skills/kernelgen-submit-feedback/
+├── SKILL.md        # 技能定义（入口文件）
+├── LICENSE.txt     # Apache 2.0 许可证
+├── README.md       # 英文文档
+└── README_zh.md    # 本文档（中文版）
+```
+
+---
+
+## 相关技能
+
+- [`kernelgen`](../kernelgen/) — 通用 GPU 算子生成
+- [`kernelgen-for-flaggems`](../kernelgen-for-flaggems/) — FlagGems 专用算子生成
+- [`kernelgen-for-vllm`](../kernelgen-for-vllm/) — vLLM 专用算子生成
+
+---
+
+## 许可证
+
+本项目基于 Apache 2.0 许可证。详见 [LICENSE.txt](LICENSE.txt)。

--- a/skills/kernelgen-submit-feedback/SKILL.md
+++ b/skills/kernelgen-submit-feedback/SKILL.md
@@ -1,0 +1,435 @@
+---
+name: kernelgen-submit-feedback
+description: >
+  Submit a GitHub issue to the flagos-ai/skills repository when a user reports a bug, defect, or
+  improvement related to a skill. Use when the user explicitly says a skill is broken or not working,
+  reports a bug or defect, asks to file a GitHub issue about a skill, or wants to submit feedback.
+  Do NOT trigger for general questions about skills or unrelated bug reports. If the user does not
+  want to use GitHub, offer the option to send feedback via email to contact@flagos.io.
+argument-hint: "[skill-name] (optional if inferable)"
+user-invokable: true
+compatibility: "GitHub CLI (gh) for issue submission, or email client for email fallback"
+metadata:
+  version: "1.0.0"
+  author: flagos-ai
+  category: feedback
+  tags: [feedback, github-issues, bug-report, skill-support]
+allowed-tools:
+  - Bash(gh:*)
+  - Bash(python:*)
+  - Bash(python3:*)
+  - Bash(command:*)
+  - Read
+  - Edit
+  - Write
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+# Submit Feedback Skill
+
+Submit issues to:
+
+https://github.com/flagos-ai/skills
+
+when users report bugs, defects, or improvements in skills.
+
+If the user does not want to create a GitHub account, they can instead send feedback via email:
+
+contact@flagos.io (for users without GitHub accounts)
+
+---
+
+# Prerequisites
+
+For GitHub submission:
+
+- GitHub CLI (`gh`) must be installed
+- The user must be authenticated
+
+---
+
+# Workflow
+
+## 1. Determine Submission Method
+
+**Default to GitHub Issue** unless the user explicitly prefers email or says they don't have
+a GitHub account. Do not ask for a preference unprompted — assume GitHub and proceed.
+
+If the user indicates they prefer email or don't have a GitHub account, switch to the
+Email Workflow.
+
+---
+
+# GitHub Workflow
+
+## 2. Gather Information
+
+Collect the following information from the user. **If the user already provided some of
+this information in the conversation, reuse it instead of asking again.**
+
+Required:
+
+- Skill name — **Infer from conversation context if obvious** (e.g., if the user says
+  "kernelgen skill crashes", auto-fill `kernelgen`). Only ask the user if the skill name
+  cannot be determined from context.
+- Problem description
+- Expected behavior
+- Actual behavior
+
+Optional (ask, but do not block on these):
+
+- Steps to reproduce
+
+## 3. Auto-collect Environment Information
+
+**Attempt** to collect environment information using the Bash tool. If the Bash tool is
+unavailable or the command fails, **do not block the workflow** — mark all environment
+fields as "Not detected" and continue.
+
+```bash
+if command -v python3 >/dev/null 2>&1; then
+  python3 - <<'PY'
+import platform, sys
+print(f"OS: {platform.system()} {platform.release()}")
+print(f"Python: {sys.version.split()[0]}")
+try:
+    import torch
+    print(f"PyTorch: {torch.__version__}")
+    print(f"CUDA: {torch.version.cuda or 'not detected'}")
+except ImportError:
+    print("PyTorch: not installed")
+    print("CUDA: not detected")
+try:
+    import triton
+    print(f"Triton: {triton.__version__}")
+except ImportError:
+    print("Triton: not installed")
+PY
+elif command -v python >/dev/null 2>&1; then
+  python - <<'PY'
+import platform, sys
+print(f"OS: {platform.system()} {platform.release()}")
+print(f"Python: {sys.version.split()[0]}")
+try:
+    import torch
+    print(f"PyTorch: {torch.__version__}")
+    print(f"CUDA: {torch.version.cuda or 'not detected'}")
+except ImportError:
+    print("PyTorch: not installed")
+    print("CUDA: not detected")
+try:
+    import triton
+    print(f"Triton: {triton.__version__}")
+except ImportError:
+    print("Triton: not installed")
+PY
+else
+  echo "PYTHON_NOT_FOUND"
+fi
+```
+
+If the output contains `PYTHON_NOT_FOUND`, or the command fails for any other reason,
+use the fallback values and move on:
+
+```
+- OS: Not detected (environment probe failed)
+- Python: Not detected (environment probe failed)
+- PyTorch: Not detected (environment probe failed)
+- CUDA: Not detected (environment probe failed)
+- Triton: Not detected (environment probe failed)
+```
+
+Include the output (or fallback values) in the Environment section of the issue.
+
+---
+
+## 4. Verify GitHub CLI
+
+First check if `gh` is installed, then check authentication:
+
+```bash
+command -v gh || echo "GH_NOT_FOUND"
+```
+
+**If the output contains the literal string `GH_NOT_FOUND`** (or is empty), **automatically
+fall back to the Email Workflow** (see below). Tell the user:
+
+    GitHub CLI (gh) was not detected on this system.
+    I will prepare an email draft instead so you can send the feedback easily.
+
+Do not stop or ask the user to install `gh` unless they explicitly want to use GitHub.
+
+**If `gh` is installed**, check authentication:
+
+```bash
+gh auth status 2>&1
+```
+
+Parse the output to determine auth state:
+- Output contains `Logged in to` or `Logged into` → authenticated, proceed.
+- Output contains `not logged in` or `authentication` error → NOT authenticated.
+- Output contains `token` and `expired` → token expired, treat as NOT authenticated.
+
+If NOT authenticated, instruct the user to run:
+
+    gh auth login
+
+Do not proceed until authentication is confirmed.
+
+---
+
+## 5. Determine Issue Type and Labels
+
+Automatically determine the issue category based on the user's report.
+
+Label rules:
+
+- If the report describes something broken or incorrect → label: `bug`
+- If the user requests a new feature or enhancement → label: `enhancement`
+- If the user suggests improvement or feedback → label: `enhancement`
+
+Always add the `skill` label as well.
+
+**Important**: Before using any label, verify it exists in the target repo. Use `--label`
+only for labels confirmed to exist. If a label does not exist, omit it rather than causing
+the `gh issue create` command to fail.
+
+To check available labels:
+
+```bash
+gh label list --repo flagos-ai/skills --limit 200 --json name
+```
+
+This outputs a JSON array like `[{"name":"bug"},{"name":"enhancement"}]`. **Extract all
+`"name"` values from the JSON array into a flat list (e.g., `["bug","enhancement","skill"]`)
+and only include `--label` flags for labels that appear in that list.** Label names are
+case-sensitive on GitHub — match them exactly as they appear in the JSON. If a desired label
+(e.g., `bug`, `skill`) does not appear, omit it from the `gh issue create` command entirely.
+Using a non-existent label will cause the command to fail.
+
+---
+
+## 6. Construct the Issue
+
+Title format:
+
+    [skill-name] Brief description
+
+Keep titles under 80 characters (preferred: under 60 for better GitHub UI display).
+**If the title exceeds 80 characters, shorten the description
+portion first** (not the skill name prefix). Do not simply truncate mid-word — rephrase the
+description to be more concise.
+
+**Generate a clear, specific title** — do not use vague user phrases like "it doesn't work"
+as-is. Summarize the actual problem based on the information gathered in Step 2. Examples:
+- Bad: `[kernelgen] it doesn't work`
+- Good: `[kernelgen] MCP call fails with schema mismatch on func_type`
+- Bad: `[submit-feedback] bug`
+- Good: `[submit-feedback] gh issue create fails when label does not exist`
+
+**If insufficient information is available** to generate a specific title, use a short generic
+description rather than guessing details. Only include facts the user actually stated.
+
+**Title uniqueness**: If you are aware that an issue with the same title already exists in
+the repo, slightly rephrase the description to make the title more specific and avoid
+duplicates.
+
+Body template (stored as a variable for use in Step 8):
+
+```
+## Skill
+
+<skill-name>
+
+## Description
+
+<description>
+
+## Steps to Reproduce
+
+<steps or "Not provided">
+
+## Expected Behavior
+
+<expected behavior>
+
+## Actual Behavior
+
+<actual behavior>
+
+## Environment
+
+- OS: <auto-collected or "Not detected">
+- Python: <auto-collected or "Not detected">
+- PyTorch: <auto-collected or "Not detected">
+- CUDA: <auto-collected or "Not detected">
+- Triton: <auto-collected or "Not detected">
+
+## Additional Context
+
+<If relevant error messages, logs, or conversation context are available, include them here.
+If the user pasted logs or stack traces earlier in the conversation, include them automatically.
+If logs exceed ~2000 characters, truncate to the most relevant portion (typically the last
+error and surrounding context) and append "... (log truncated, showing last relevant section)".
+Otherwise write "None".>
+
+---
+
+Submitted via submit-feedback skill
+```
+
+---
+
+## 7. Confirm With User
+
+Show the generated issue title, body, and labels to the user and ask for confirmation before
+submitting. Do not submit without explicit user approval.
+
+---
+
+## 8. Submit the Issue
+
+**Use `--body-file -` with a HEREDOC** to pass the body via stdin. This avoids shell escaping
+issues with multiline markdown and the "Argument list too long" error for large bodies:
+
+**Important**: The `--label` flags in the example above are illustrative. **Only include labels
+verified to exist** in Step 5. If `bug` or `skill` does not appear in the `gh label list`
+output, omit that `--label` flag entirely. Example with no verified labels:
+
+```bash
+gh issue create \
+  --repo flagos-ai/skills \
+  --title "[skill-name] Brief description" \
+  --body-file - <<'__ISSUE_BODY_FLAGOS_SKILL__'
+## Skill
+
+<skill-name>
+
+## Description
+
+<description>
+
+## Steps to Reproduce
+
+<steps or "Not provided">
+
+## Expected Behavior
+
+<expected behavior>
+
+## Actual Behavior
+
+<actual behavior>
+
+## Environment
+
+- OS: ...
+- Python: ...
+- PyTorch: ...
+- CUDA: ...
+- Triton: ...
+
+## Additional Context
+
+<error messages, logs, or relevant conversation context — or "None">
+
+---
+
+Submitted via submit-feedback skill
+__ISSUE_BODY_FLAGOS_SKILL__
+```
+
+**Never use `"$BODY"` with shell variable expansion** or `--body "$(cat ...)"` — multiline
+markdown content with backticks, quotes, and special characters will break the command.
+Always use `--body-file -` with HEREDOC as shown above.
+
+---
+
+## 9. Confirm Creation
+
+Show the created issue URL and number.
+
+Example:
+
+    Issue #42 created: https://github.com/flagos-ai/skills/issues/42
+
+If the command fails, show the error to the user and suggest they create the issue manually
+at https://github.com/flagos-ai/skills/issues/new with the body text you prepared.
+
+---
+
+# Email Workflow (Alternative)
+
+The Email Workflow is used when:
+- The user explicitly prefers email
+- The user does not have a GitHub account
+- GitHub CLI (`gh`) is not available (automatic fallback from Step 4)
+
+Prepare an email draft and provide a `mailto:` link.
+
+Recipient:
+
+    contact@flagos.io
+
+Subject:
+
+    [Skill Feedback] <skill-name> - Brief description
+
+Body template:
+
+```
+Skill: <skill-name>
+
+Description:
+<description>
+
+Steps to Reproduce:
+<steps or "Not provided">
+
+Expected Behavior:
+<expected behavior>
+
+Actual Behavior:
+<actual behavior>
+
+Environment:
+- OS: <auto-collected or "Not detected">
+- Python: <auto-collected or "Not detected">
+- PyTorch: <auto-collected or "Not detected">
+- CUDA: <auto-collected or "Not detected">
+- Triton: <auto-collected or "Not detected">
+
+Additional Context:
+<error messages, logs, or relevant conversation context — or "None">
+
+Submitted via skill feedback email
+```
+
+After showing the draft, provide **two options** for the user:
+
+1. **mailto link** (for users with a configured email client):
+   ```
+   mailto:contact@flagos.io?subject=[Skill Feedback] <skill-name> - Brief description&body=<url-encoded body>
+   ```
+   **URL-encode the body text** before inserting it into the mailto link (spaces → `%20`,
+   newlines → `%0A`, etc.). Unencoded special characters will break the link.
+   **Note**: `mailto:` links have a ~2000 character limit. If the URL-encoded body exceeds
+   this, skip the mailto link and only offer option 2.
+2. **Copy-paste**: Tell the user to copy the draft above and send it manually to
+   `contact@flagos.io`. This is the most reliable option and works regardless of email
+   client or body length.
+
+---
+
+# Rules
+
+- Always confirm the issue or email content before sending.
+- Never fabricate details. If information is missing, write "Not provided".
+- Auto-collect environment info — do not ask the user for OS/Python/PyTorch versions.
+- Keep submissions in English. If the user provides Chinese text, translate it before submission.
+- If `gh` or authentication is not available, do not attempt workarounds — guide the user
+  to install/authenticate or switch to the email workflow.
+- Do not include sensitive information (API keys, tokens, passwords) in the issue body.
+  If the user's logs contain secrets, redact them before submission.

--- a/skills/kernelgen/LICENSE.txt
+++ b/skills/kernelgen/LICENSE.txt
@@ -1,0 +1,200 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get an
+      OpenPGP-compatible signature of your completed statement.
+
+   Copyright 2026 BAAI (Beijing Academy of Artificial Intelligence)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/kernelgen/README.md
+++ b/skills/kernelgen/README.md
@@ -1,0 +1,116 @@
+# kernelgen: GPU Kernel Operator Generation (General Purpose)
+
+[中文版](README_zh.md)
+
+## Overview
+
+`kernelgen` is an AI coding skill that generates GPU kernel operators via the `kernelgen-mcp` MCP service and integrates them into any Python/Triton repository.
+
+### Problem Statement
+
+Writing high-performance GPU kernels is complex and error-prone. Developers must handle Triton pointer arithmetic, memory access patterns, autotuning configurations, and project-specific conventions. Each repository has its own file layout, coding style, and testing patterns, making it hard to generate code that fits seamlessly.
+
+This skill automates the entire workflow: **environment check → repo discovery → MCP generation → code adaptation → accuracy testing → performance benchmarking**, spanning 10 steps with automatic convention detection and code transformation.
+
+### Usage
+
+```bash
+# Generate a kernel operator
+/kernelgen relu
+
+# Generate with explicit function type
+/kernelgen rms_norm --func-type normalization
+
+# Generate for any operator
+/kernelgen silu_and_mul
+```
+
+| Argument | Required | Default | Description |
+|---|---|---|---|
+| `operator_name` | Yes | — | Operator name in snake_case (e.g. `relu`, `rms_norm`, `silu_and_mul`) |
+| `--func-type` | No | Auto-inferred | One of: `unary_pointwise`, `binary_pointwise`, `reduction`, `normalization`, `attention`, `activation`, `quantization`, `moe`, `blas`, `sampling`, `other` |
+
+---
+
+## Generation Pipeline (10 Steps)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Step 0   Pre-flight: Environment & MCP Check            │
+│  Step 1   Understand the Operator Request                │
+│  Step 2   Discover Repository Structure                  │
+│  Step 3   Check Whether Operator Already Exists          │
+│  Step 4   Research Context (flagos_wiki)                 │
+│  Step 5   Call kernelgen-mcp                             │
+│  Step 6   Adapt and Place Code into Repository           │
+│  Step 6.5 Pre-test Validation                            │
+│  Step 7   Run Accuracy Tests                             │
+│  Step 8   Run Performance Benchmark                      │
+│  Step 9   Summary Report                                 │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Key Features
+
+- **Dynamic repo discovery** — automatically detects project structure, operator directories, test directories, and conventions
+- **Convention matching** — reads existing code to match import style, naming conventions, license headers, and autotune patterns
+- **Smart code transformation** — adapts MCP-generated code to match repo patterns (wrapper style vs raw Triton)
+- **Existing operator detection** — searches for naming variants before generating to avoid duplicates
+- **Comprehensive testing** — runs accuracy tests with per-dtype tolerances and performance benchmarks
+- **Error recovery** — structured retry protocol with MCP re-generation and optimization fallbacks
+
+---
+
+## Directory Structure
+
+```
+skills/kernelgen/
+├── SKILL.md        # Skill definition (entry point)
+├── LICENSE.txt     # Apache 2.0 license
+├── README.md       # This document (English)
+└── README_zh.md    # Chinese version
+```
+
+---
+
+## File Descriptions
+
+### `SKILL.md`
+
+The skill entry point. Defines the complete 10-step workflow for generating GPU kernel operators in any Python/Triton repository. Includes environment checking, repo structure discovery, MCP code generation, convention-aware code placement, accuracy testing, and performance benchmarking.
+
+---
+
+## Usage in FlagOS Skills Repository
+
+### Quick Install (via npx)
+
+```bash
+# Install this skill only
+npx skills add flagos-ai/skills --skill kernelgen -a claude-code
+
+# Or install all Flagos skills at once
+npx skills add flagos-ai/skills -a claude-code
+```
+
+### Manual Install
+
+```bash
+# From your project root
+mkdir -p .claude/skills
+cp -r <path-to-this-repo>/skills/kernelgen .claude/skills/
+```
+
+---
+
+## Related Skills
+
+- [`kernelgen-for-flaggems`](../kernelgen-for-flaggems/) — Specialized for FlagGems repositories
+- [`kernelgen-for-vllm`](../kernelgen-for-vllm/) — Specialized for vLLM repositories
+- [`kernelgen-submit-feedback`](../kernelgen-submit-feedback/) — Submit bug reports and feedback
+
+---
+
+## License
+
+This project is licensed under the Apache 2.0 License. See [LICENSE.txt](LICENSE.txt) for details.

--- a/skills/kernelgen/README_zh.md
+++ b/skills/kernelgen/README_zh.md
@@ -1,0 +1,84 @@
+# kernelgen：GPU 算子生成（通用版）
+
+## 概述
+
+`kernelgen` 是一个 AI 编程技能，通过 `kernelgen-mcp` MCP 服务生成 GPU 算子，并将其集成到任意 Python/Triton 仓库中。
+
+### 解决的问题
+
+编写高性能 GPU 算子复杂且容易出错。开发者需要处理 Triton 指针运算、内存访问模式、自动调优配置以及项目特定的代码规范。每个仓库都有各自的文件布局、编码风格和测试模式，生成符合项目规范的代码非常困难。
+
+本技能自动化了整个工作流程：**环境检查 → 仓库结构发现 → MCP 代码生成 → 代码适配 → 准确性测试 → 性能基准测试**，涵盖 10 个步骤，支持自动检测项目规范并进行代码转换。
+
+### 使用方式
+
+```bash
+# 生成算子
+/kernelgen relu
+
+# 指定函数类型
+/kernelgen rms_norm --func-type normalization
+
+# 生成任意算子
+/kernelgen silu_and_mul
+```
+
+| 参数 | 必填 | 默认值 | 说明 |
+|---|---|---|---|
+| `operator_name` | 是 | — | snake_case 格式的算子名称（如 `relu`、`rms_norm`、`silu_and_mul`） |
+| `--func-type` | 否 | 自动推断 | 可选: `unary_pointwise`、`binary_pointwise`、`reduction`、`normalization`、`attention`、`activation`、`quantization`、`moe`、`blas`、`sampling`、`other` |
+
+---
+
+## 生成流水线（10 步）
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  步骤 0   预检：环境与 MCP 检查                           │
+│  步骤 1   理解算子需求                                    │
+│  步骤 2   发现仓库结构                                    │
+│  步骤 3   检查算子是否已存在                               │
+│  步骤 4   研究上下文（flagos_wiki）                        │
+│  步骤 5   调用 kernelgen-mcp                              │
+│  步骤 6   适配代码并放置到仓库                             │
+│  步骤 6.5 测试前验证                                      │
+│  步骤 7   运行准确性测试                                   │
+│  步骤 8   运行性能基准测试                                 │
+│  步骤 9   生成报告                                        │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 核心特性
+
+- **动态仓库发现** — 自动检测项目结构、算子目录、测试目录和代码规范
+- **规范匹配** — 读取现有代码以匹配导入风格、命名规范、许可证头和自动调优模式
+- **智能代码转换** — 将 MCP 生成的代码适配为仓库特定的模式（包装器风格 vs 原始 Triton）
+- **已有算子检测** — 生成前搜索命名变体以避免重复
+- **全面测试** — 按数据类型精度运行准确性测试和性能基准测试
+- **错误恢复** — 结构化重试协议，支持 MCP 重新生成和优化回退
+
+---
+
+## 目录结构
+
+```
+skills/kernelgen/
+├── SKILL.md        # 技能定义（入口文件）
+├── LICENSE.txt     # Apache 2.0 许可证
+├── README.md       # 英文文档
+└── README_zh.md    # 本文档（中文版）
+```
+
+---
+
+## 相关技能
+
+- [`kernelgen-for-flaggems`](../kernelgen-for-flaggems/) — FlagGems 仓库专用版
+- [`kernelgen-for-vllm`](../kernelgen-for-vllm/) — vLLM 仓库专用版
+- [`kernelgen-submit-feedback`](../kernelgen-submit-feedback/) — 提交 bug 报告和反馈
+
+---
+
+## 许可证
+
+本项目基于 Apache 2.0 许可证。详见 [LICENSE.txt](LICENSE.txt)。

--- a/skills/kernelgen/SKILL.md
+++ b/skills/kernelgen/SKILL.md
@@ -1,0 +1,971 @@
+---
+name: kernelgen
+description: >
+  Generate GPU kernel operators via kernelgen-mcp and integrate them into the current repository.
+  Checks environment & MCP availability, discovers repo structure, calls the code generator,
+  places files in the correct project locations following local conventions, and runs accuracy
+  + benchmark tests. Works with any Python/Triton project. Use this skill when the user wants
+  to generate a GPU kernel operator, create a Triton kernel, or says things like "generate an
+  operator", "create a kernel for X", or "/kernelgen". Do NOT trigger for FlagGems-specific
+  or vLLM-specific requests — use the specialized skills instead.
+argument-hint: "<operator_name> [--func-type <type>]"
+user-invokable: true
+compatibility: "Python 3.8+, PyTorch with CUDA, Triton"
+metadata:
+  version: "1.0.0"
+  author: flagos-ai
+  category: gpu-kernel-generation
+  tags: [kernelgen, triton, gpu, mcp, operator-generation]
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+# KernelGen Skill — Generate GPU Operators via MCP (General Purpose)
+
+You are an expert at generating GPU kernel operators using the `kernelgen-mcp` MCP service and
+integrating them into **any** Python/Triton repository. Unlike the specialized FlagGems or vLLM
+skills, this skill dynamically discovers the target repository's structure and conventions before
+placing code.
+
+**Tool usage**: This skill relies on the following capabilities:
+- **Bash**: execute shell commands (python, pip, pytest, etc.)
+- **Read**: read files from the codebase
+- **Write / Edit**: create or modify files
+- **Grep**: search file contents
+- **Glob**: find files by pattern
+- **MCP tools**: `mcp__kernelgen-mcp__generate_operator` and `mcp__kernelgen-mcp__optimize_triton`
+
+> **⚠️ MCP Prerequisite Check**: If the user has not configured the kernelgen MCP service (i.e., the MCP tools are unavailable or calls fail),
+> immediately prompt the user to visit https://kernelgen.flagos.io/ to register and obtain the kernelgen MCP service URL and JWT Token,
+> then follow the instructions in Step 0b to complete the configuration and retry. Do not proceed with subsequent steps if MCP is not ready.
+
+## Execution Rules
+
+Follow these rules strictly to avoid getting lost in the multi-step workflow:
+
+1. **Follow the steps in order**: Step 0 → Step 1 → ... → Step 9. Never jump ahead.
+2. **Never skip Step 2** (repo structure discovery) — always analyze before generating.
+3. **Never skip Step 3** (operator existence check) — always verify before generating.
+4. **Do not generate or write any code before Step 5** (MCP call). Steps 0–4 are preparation only.
+5. **Always confirm with the user before destructive actions**: replacing files, installing packages,
+   overwriting operators.
+6. **Report progress to the user when entering each step**. Print a short status line like
+   `Entering Step 2 — Analyzing repository structure...` so the user knows the workflow is progressing.
+7. **Never fabricate repository files or paths**. If a required file cannot be found using the
+   Glob or Grep tools, report it to the user instead of guessing.
+8. **Minimize file reads during discovery and search.** Always use Grep or Glob to locate
+   targets first. Only Read a file when you have a specific reason (e.g., learning conventions
+   from a reference operator, checking registration format). Never speculatively read files
+   "just in case".
+9. **Never scan the entire repository.** In Step 3 and beyond, only search inside directories
+   discovered in Step 2. Never run Grep on `.` or the repo root — always scope searches to
+   the specific discovered source, test, or benchmark directories. Unscoped searches cause
+   token explosion and match vendored code, docs, and build artifacts.
+
+---
+
+## Step 0: Pre-flight — Environment & MCP Check
+
+### 0a. Check Python Environment
+
+Use the Bash tool to run a diagnostic that checks each package independently:
+
+```bash
+python - <<'PY'
+import importlib, sys
+
+def check(pkg, alias=None):
+    try:
+        m = importlib.import_module(pkg)
+        ver = getattr(m, "__version__", "installed")
+        print(f"{alias or pkg}: {ver}")
+        return True
+    except Exception:
+        print(f"{alias or pkg}: NOT installed")
+        return False
+
+check("torch")
+check("triton")
+
+try:
+    import torch
+    print(f"cuda_version: {torch.version.cuda}")
+    print(f"cuda_available: {torch.cuda.is_available()}")
+    if torch.cuda.is_available():
+        for i in range(torch.cuda.device_count()):
+            print(f"  cuda:{i} {torch.cuda.get_device_name(i)}")
+except Exception:
+    pass
+
+check("pytest")
+check("numpy")
+PY
+```
+
+**If any import fails**, stop and ask the user before installing anything. Present the missing
+packages and let the user confirm:
+
+| Missing package | Suggested install command | Notes |
+|---|---|---|
+| `torch` | Ask the user | User MUST pick the correct CUDA variant. Never auto-install torch. |
+| `triton` | `pip install triton` | |
+| `pytest` | `pip install pytest` | |
+| `numpy` | `pip install numpy` | |
+
+**Important**: Never install `torch` without asking the user which CUDA version they need.
+
+If `torch` is installed but `torch.cuda.is_available() == False`, warn the user that GPU tests
+will fail and ask how to proceed.
+
+After the user confirms and packages are installed, re-run the diagnostic. Only proceed when
+torch and triton imports succeed.
+
+### 0b. Check MCP Availability
+
+Use the Read tool to check for MCP configuration. **Only check project-local paths** — do NOT
+attempt to read user home directory (`~/`) as Claude Code typically cannot access it:
+
+1. `.claude/settings.json` — look for `mcpServers` containing the key `"kernelgen-mcp"`
+2. `.mcp.json` — same check
+
+If found, check whether the exact key `"kernelgen-mcp"` exists under `mcpServers`.
+Do NOT use substring matching (e.g., matching `"kernelgen"` inside another key name).
+
+**If the MCP server is NOT found in either file**, ask the user:
+
+```
+kernelgen-mcp service was not detected in the project configuration.
+
+Possible scenarios:
+  A) Not yet configured — Please visit https://kernelgen.flagos.io/ to register and obtain a JWT Token,
+     then provide me with the URL and Token, and I will write them to .claude/settings.json.
+  B) Already configured globally — If you have already configured kernelgen-mcp in your global settings,
+     please let me know and I will skip this step and continue.
+
+The final configuration format is as follows (.claude/settings.json):
+{
+  "mcpServers": {
+    "kernelgen-mcp": {
+      "type": "sse",
+      "url": "<YOUR_URL>",
+      "headers": {
+        "Authorization": "Bearer <YOUR_JWT_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+Wait for the user to respond. Then:
+- If the user provides URL + JWT: use the Edit tool (or Write tool if the file doesn't exist)
+  to write the configuration, **merging** with any existing content (never overwrite other MCP
+  server entries or top-level keys). Tell the user to restart Claude Code.
+- If the user says MCP is configured globally: proceed to Step 1.
+
+**If the MCP server IS configured**, proceed to Step 1.
+
+---
+
+## Step 1: Understand the Operator Request
+
+Parse the user's description to determine:
+- `kernel_name`: operator name in **snake_case** (e.g., `rms_norm`, `relu`, `softmax`)
+- `func_desc`: what the operator does
+- `func_type`: one of `unary_pointwise`, `binary_pointwise`, `reduction`, `normalization`,
+  `attention`, `activation`, `quantization`, `moe`, `blas`, `sampling`, `other`.
+  **Auto-infer from the operator signature when possible:**
+  - If 1 tensor input, no dim arg → `unary_pointwise`
+  - If operator has >=2 tensor inputs → `binary_pointwise`
+  - If has a `dim` argument → `reduction`
+  - If name contains `norm`, `softmax`, `rmsnorm`, `layernorm`, `batchnorm` → `normalization`
+  - If name contains `relu`, `gelu`, `silu`, `swish`, `tanh`, `sigmoid` → `activation`
+  - If name is `mm`, `matmul`, `bmm`, `addmm` → `blas`
+  - If name contains `attention`, `flash`, `paged` → `attention`
+  - If name contains `quant`, `awq`, `gptq` → `quantization`
+  - If name contains `moe`, `expert` → `moe`
+  - Otherwise → `other`
+  Confirm the inferred `func_type` with the user if ambiguous.
+- `arg_names`, `arg_type`, `arg_descs`, `output_arg_desc`: parameter information
+
+**Normalize `kernel_name` to snake_case** before using it anywhere:
+- `RMSNorm` → `rms_norm`
+- `SiluAndMul` → `silu_and_mul`
+- `LayerNorm` → `layer_norm`
+
+Check this common alias table before asking the user:
+
+| User says | Correct `kernel_name` |
+|---|---|
+| swish | `silu` |
+| negative / negate | `neg` |
+| power | `pow` |
+| absolute | `abs` |
+| multiply | `mul` |
+| divide | `div` |
+| clip | `clamp` |
+| hard_swish | `hardswish` |
+| hard_sigmoid | `hardsigmoid` |
+| logarithm / ln | `log` |
+| exponential | `exp` |
+| hyperbolic_tangent | `tanh` |
+| square | `pow (exp=2)` |
+| square_root | `sqrt` |
+| cube | `pow (exp=3)` |
+| cube_root | `cbrt` |
+| inverse_sqrt | `rsqrt` |
+| reciprocal / inverse | `reciprocal` |
+| minimum | `min` |
+| maximum | `max` |
+| floor_divide | `floor_divide` |
+| modulo / mod | `remainder` |
+
+### Complexity Gate
+
+Before proceeding, check the `func_type`. If it is one of the following **complex** types,
+warn the user and ask for explicit confirmation before continuing:
+
+- `attention`
+- `moe`
+- `quantization`
+- `sampling`
+
+```
+Note: Operators of type <func_type> are relatively complex. KernelGen's auto-generation success rate is approximately 60%,
+and manual tuning may be required. Do you want to proceed with generation?
+```
+
+For simpler types (`unary_pointwise`, `binary_pointwise`, `reduction`, `normalization`,
+`activation`, `blas`), proceed without warning — these have >90% success rate.
+
+### Argument Inference
+
+**If argument information is missing or the description is vague**:
+
+1. Use the Grep tool to search for the operator name **only inside directories discovered in
+   Step 2** (source dirs, test dirs, kernel dirs) to infer argument signatures from existing
+   code. **Never grep the repo root or unscoped paths** — this causes token explosion in
+   large repos.
+2. Present the inferred signature to the user for confirmation before proceeding.
+3. **Fallback**: If no matches are found, use a default signature based on `func_type`:
+
+   | func_type | Default args |
+   |---|---|
+   | `unary_pointwise`, `activation` | `arg_names: ["x"]`, `arg_type: ["torch.Tensor"]` |
+   | `binary_pointwise` | `arg_names: ["x", "y"]`, `arg_type: ["torch.Tensor", "torch.Tensor"]` |
+   | `normalization` | `arg_names: ["x", "weight"]`, `arg_type: ["torch.Tensor", "torch.Tensor"]` |
+   | `reduction` | `arg_names: ["x"]`, `arg_type: ["torch.Tensor"]` |
+   | `attention` | `arg_names: ["q", "k", "v"]`, `arg_type: ["torch.Tensor", "torch.Tensor", "torch.Tensor"]` |
+   | `blas` | `arg_names: ["a", "b"]`, `arg_type: ["torch.Tensor", "torch.Tensor"]` |
+   | other | `arg_names: ["x"]`, `arg_type: ["torch.Tensor"]` |
+
+   Present the default to the user and ask them to confirm or refine. **Do not send defaults
+   directly to MCP without user confirmation** — a wrong signature causes schema errors.
+
+---
+
+## Step 2: Discover Repository Structure
+
+**This step is critical.** Unlike the FlagGems/vLLM-specific skills, we do NOT assume any fixed
+directory layout. Instead, we dynamically discover the project structure.
+
+### 2a. Identify the Project Type
+
+Use the Glob and Read tools to check for project identity:
+
+```
+Glob: pyproject.toml, setup.py, setup.cfg
+```
+
+Read `pyproject.toml` (or `setup.py` / `setup.cfg`) to determine:
+- **Project name** (e.g., `flag_gems`, `vllm`, `lmdeploy`, etc.)
+- **Source root** (e.g., `src/`, `.`, `lib/`)
+- **Package name** — the importable top-level module
+
+**Known-project shortcut**: If the project name matches a known specialized skill, inform
+the user and suggest switching:
+
+| Project name | Specialized skill | Suggestion |
+|---|---|---|
+| `flag_gems` / `FlagGems` | `/kernelgen_for_flaggems` | "Detected FlagGems repository. It is recommended to use the specialized skill `/kernelgen_for_flaggems` for a higher success rate. Would you like to switch?" |
+| `vllm` | `/kernelgen_for_vllm` | "Detected vLLM repository. It is recommended to use the specialized skill `/kernelgen_for_vllm` for a higher success rate. Would you like to switch?" |
+
+If the user agrees, stop and tell them to invoke the specialized skill. If the user declines
+or the project is not in the table, continue with the general skill.
+
+### 2b. Map Key Directories
+
+Use the Glob tool with **shallow patterns** to avoid token explosion in large repos. Do NOT
+use deep recursive `**` patterns that could match thousands of files.
+
+**Important**: If any single Glob returns more than 20 matches, **stop inspecting that
+pattern** — just record the directory prefix (e.g., `src/pkg/ops/`) and move on. Do NOT
+read or list all matched files; only note the directory structure.
+
+```
+Glob: src/*/ops/*.py          (source ops — one level under src/)
+Glob: src/*/kernels/*.py      (source kernels)
+Glob: */ops/*.py              (top-level package ops)
+Glob: */kernels/*.py          (top-level package kernels)
+Glob: tests/*.py              (top-level tests)
+Glob: tests/kernels/*.py      (kernel-specific tests)
+Glob: benchmark*/*.py         (benchmarks)
+Glob: benchmark*/kernels/*.py (kernel benchmarks)
+```
+
+If these shallow patterns return no results for a category, try ONE level deeper:
+```
+Glob: src/*/*/ops/*.py
+Glob: src/*/*/kernels/*.py
+```
+
+If **still** no operator directory is found, run a generic fallback scan:
+```
+Glob: src/*/*kernel*.py
+Glob: src/*/*op*.py
+```
+This catches non-standard directory names like `triton_kernels/`, `gpu_ops/`, `cuda_ops/`.
+
+**Stop expanding once you find matches.** Do not keep globbing deeper.
+
+**Early-stop rule**: Once you have discovered both an **operator source directory** and a
+**test directory**, stop all further glob exploration. Do not continue searching for additional
+directories — two anchors are sufficient to infer the rest of the layout.
+
+**Disambiguation rule**: If multiple operator directories are discovered (e.g., `src/foo/ops/`
+and `src/bar/ops/`), **prefer the one that belongs to the main package name** detected in
+Step 2a (`pyproject.toml`). If still ambiguous, ask the user which directory to use.
+
+Record the discovered layout in this table (fill in dynamically):
+
+| Purpose | Discovered Path |
+|---------|----------------|
+| **Operator source code** | _(e.g., `src/pkg/ops/`, `pkg/kernels/`, etc.)_ |
+| **Tests (accuracy)** | _(e.g., `tests/`, `tests/kernels/`, etc.)_ |
+| **Benchmarks** | _(e.g., `benchmark/`, `benchmarks/kernels/`, etc.)_ |
+| **Init/registry files** | _(e.g., `src/pkg/ops/__init__.py`, etc.)_ |
+| **Custom op registration** | _(e.g., `pkg/_custom_ops.py`, etc.)_ |
+
+### 2c. Study Existing Operators as Reference
+
+Find an existing operator implementation similar to the requested one and read it to learn:
+
+1. **Import style** — what modules are imported, decorator patterns
+2. **Kernel style** — raw Triton pointer-based, or higher-level wrappers like `pointwise_dynamic`
+3. **Function naming** — snake_case, prefix/suffix conventions (e.g., `_kernel`, `_forward`)
+4. **Wrapper pattern** — how the Python wrapper calls the Triton kernel
+5. **License headers** — whether files start with SPDX or other license headers
+6. **Logging** — which logging approach is used (e.g., `vllm.logger.init_logger`, stdlib `logging`)
+7. **Autotune usage** — whether the repo uses `@triton.autotune` and which BLOCK_SIZE configs.
+   If autotune is used, also note `num_warps` and `num_stages` values from existing configs —
+   these will be replicated for the new kernel's autotune configs in Step 6.
+
+Also read the matching test and benchmark files to learn:
+- **Test pattern**: parametrize style, shapes, dtypes, assertion utilities
+- **Benchmark pattern**: timing methodology, reporting format
+
+**Store all discovered conventions** — they will be applied in Step 6.
+
+---
+
+## Step 3: Check Whether the Operator Already Exists
+
+Before calling the MCP generator, **thoroughly search** the codebase for existing implementations
+using the Glob and Grep tools.
+
+### 3a. Generate Search Variants
+
+From `kernel_name`, generate **all naming variants** to search:
+- snake_case: `layer_norm`
+- concatenated lowercase: `layernorm`
+- CamelCase: `LayerNorm`
+- Partial components (for compound names): only if `kernel_name` contains `_and_` or `_with_`,
+  split and search components **longer than 4 characters**. Example:
+  - `silu_and_mul` → search `silu` (5 chars, OK), skip `mul` (3 chars, too short)
+  - `add_relu` → do NOT split (no `_and_` / `_with_`), search as whole name only
+  Short fragments like `mul`, `add`, `div`, `neg` match too many unrelated symbols.
+
+### 3b. Search
+
+For **each** naming variant, search:
+1. **Source files**: Glob for `*<variant>*.py` in discovered source directories (shallow)
+2. **Function and class definitions**: Grep for these patterns in discovered source directories:
+   - `def <variant>` — direct function definition
+   - `<variant>_kernel` — kernel function naming convention
+   - `<variant>_forward` — forward function naming convention
+   - `<variant>_backward` — backward function naming convention
+   - `class <CamelCaseVariant>` — class-based operator (e.g., `class LayerNorm`,
+     `class SoftmaxKernel`, `class RMSNormOp`)
+   - `register_op("<variant>")` / `OP_REGISTRY["<variant>"]` / `aten_map["<variant>"]` —
+     dispatch-style registration where the implementation function name may differ from
+     the operator name
+   This catches operators that live inside files with different names (e.g., `softmax_kernel`
+   inside `normalization.py`, or `silu_and_mul` inside `activation.py`).
+3. **Init/registry**: Grep for `<variant>` in all `__init__.py` files and any custom op
+   registration files found in Step 2
+4. **Tests**: Grep for `<variant>` in discovered test directories
+5. **Benchmarks**: Grep for `<variant>` in discovered benchmark directories
+
+### If the operator already exists
+
+Present findings to the user and ask them to choose. **Stop and wait** for the user's explicit
+choice before continuing:
+
+> Detected that the `<kernel_name>` operator already exists in the repository:
+> - Implementation: `<file path>`
+> - Tests: `<file path>`
+> - Benchmarks: `<file path>`
+>
+> Please choose how to proceed:
+>
+> **A — Cancel generation**: Keep the existing operator unchanged.
+>
+> **B — Replace existing**: Replace the current implementation with a new version generated by KernelGen.
+>
+> **C — Add custom variant side-by-side**: Keep the existing operator and place the new version as `<kernel_name>_v2` alongside it, so both coexist.
+
+Only proceed to Step 4 after the user has made a choice.
+
+### If the operator does NOT exist
+
+Proceed directly to Step 4.
+
+---
+
+## Step 4: Research Context (flagos_wiki)
+
+Before calling the MCP generator, use the Read tool to gather reference materials that improve
+generation quality:
+
+1. **Read similar operator code** from the codebase — pick the most similar existing operator
+   to the one being generated (same `func_type`).
+
+2. **Read the test pattern** from the matching test file to understand shapes, dtypes, assertions.
+
+3. **Read the benchmark pattern** from the matching benchmark file to understand timing methodology.
+
+4. **If replacing an existing op** (Option B), read the current implementation so the new version
+   can be compared / improved upon.
+
+   **If reference files cannot be found**, do not stop. Proceed with general algorithm hints
+   based on your knowledge of the operator type. An empty or minimal `flagos_wiki` is acceptable.
+
+5. Collect all findings into the `flagos_wiki` parameter as a `List[str]`. Rules:
+   - Each string should be a concise reference snippet, **under 200 characters**.
+   - **Maximum 10 items** — avoid token explosion.
+   - **Prefer algorithm insights over file path descriptions**.
+   - **Always include a kernel pattern hint** as the first item (e.g.,
+     `"Kernel pattern: elementwise"`, `"Kernel pattern: row-wise reduction over hidden_size"`).
+   - **Always include `"Use Triton for GPU parallelization"` as the second item** — this
+     anchors the generator toward Triton output and reduces fallback failures.
+   - **Always include a memory layout hint** (e.g.,
+     `"Input tensors are contiguous row-major layout"`).
+   - **Include a memory access pattern hint if inferable** from the `func_type` (e.g.,
+     `"Memory access: coalesced contiguous loads"` for pointwise/elementwise,
+     `"Memory access: row-wise strided reads over hidden_size"` for normalization/reduction).
+     This significantly improves generated kernel quality.
+   - Include relevant conventions discovered in Step 2 (e.g.,
+     `"Repo uses pointwise_dynamic wrapper for elementwise ops"`,
+     `"Repo uses @triton.autotune with BLOCK_SIZE configs [64,128,256,512]"`).
+
+---
+
+## Step 5: Call kernelgen-mcp
+
+Invoke `mcp__kernelgen-mcp__generate_operator` with the parameters gathered above:
+
+```
+kernel_name:     "<kernel_name>"
+func_desc:       "<description of what the operator does>"
+func_type:       "<func_type>"
+arg_names:       [<list of argument names>]
+arg_type:        [<list of argument types>]
+arg_descs:       [<list of argument descriptions>]
+output_arg_desc: "<description of the output>"
+flagos_wiki:        [<list of reference strings from Step 4>]
+```
+
+The MCP returns code blocks which may include:
+- `torch_code` — PyTorch reference implementation
+- `triton_code` — Triton kernel implementation
+- `test_func_code` — accuracy test code
+- `benchmark_func_code` — performance benchmark code
+
+**If `torch_code` is missing**, construct a `ref_impl` yourself using standard PyTorch ops
+based on `func_desc`.
+
+### MCP Failure Retry Strategy
+
+If the MCP call fails, apply retries in this order:
+
+1. **First retry**: Remove `flagos_wiki` parameter and call again (handles `unexpected argument`
+   / `unknown field` / `invalid schema` errors).
+2. **Second retry**: Use minimal parameters only (`kernel_name`, `func_desc`, `func_type`,
+   `arg_names`, `arg_type`) — drop `arg_descs`, `output_arg_desc`, and `flagos_wiki`.
+3. **Third retry**: Change `func_type` to `"other"` and keep only minimal parameters. This
+   handles `func_type` mismatch errors where the MCP backend does not recognize the original
+   `func_type` value (e.g., `activation` vs `unary_pointwise`).
+4. **If still failing**: Stop and report the exact error to the user. Do NOT keep retrying.
+
+---
+
+## Step 6: Adapt and Place Code into the Repository
+
+This is the most critical step. The generated code must be **transformed to match the local
+repository's conventions** discovered in Step 2.
+
+### 6a. Transform the Kernel Code
+
+Apply the conventions discovered in Step 2c. **The decision to rewrite depends entirely on
+what the repo actually uses** — never assume:
+
+**Only rewrite to wrapper style if BOTH conditions are met**:
+1. The repo explicitly uses wrapper utilities (e.g., FlagGems `pointwise_dynamic`).
+2. The reference operator's kernel function signature receives **scalar elements** (not pointers).
+
+If either condition is unclear, **keep the MCP-generated raw Triton pointer-based code**.
+Misidentifying wrapper style produces completely broken kernels.
+
+When rewriting to wrapper style:
+- The `@triton.jit` kernel should receive **scalar elements** (not pointers).
+- **Remove ALL** `tl.load()`, `tl.store()`, pointer arithmetic, mask logic, and BLOCK_SIZE
+  parameters — the wrapper handles these automatically.
+- Only keep the pure math expression.
+
+**Otherwise, keep the MCP-generated raw Triton pointer-based code.** This is the safer default
+for most repositories. Apply these adaptations:
+- **Match the repo's autotune convention exactly**:
+  - If existing kernels use `@triton.autotune` → add it, using the same BLOCK_SIZE configs
+    found in existing kernels.
+  - If existing kernels do **NOT** use `@triton.autotune` (e.g., torchinductor, tinygrad, some
+    inference engines explicitly avoid it) → do **NOT** introduce it. Use a fixed BLOCK_SIZE
+    matching the repo's pattern instead.
+  - If no existing kernels are found for reference, use a default autotune set:
+  ```python
+  @triton.autotune(
+      configs=[
+          triton.Config({"BLOCK_SIZE": 64}, num_warps=4),
+          triton.Config({"BLOCK_SIZE": 128}, num_warps=4),
+          triton.Config({"BLOCK_SIZE": 256}, num_warps=8),
+          triton.Config({"BLOCK_SIZE": 512}, num_warps=8),
+      ],
+      key=["n_elements"],  # replace with actual problem-size arg name
+  )
+  ```
+- Ensure proper `tl.constexpr` for meta parameters.
+- Use `triton.cdiv` for grid computation.
+
+**Common adaptations for all repos:**
+- Add the repo's standard license header (if any, discovered in Step 2c).
+- Use the repo's logging approach (e.g., `vllm.logger.init_logger`, `logging.getLogger`).
+- Follow the repo's naming conventions for kernel functions (e.g., `_kernel` suffix, `_forward`
+  suffix).
+- Match import style exactly.
+
+### 6b. Determine File Placement
+
+Place files according to the layout discovered in Step 2b:
+
+| File | Location |
+|------|----------|
+| Kernel implementation | Discovered operator source directory + `<kernel_name>.py` |
+| Accuracy test | Discovered test directory + `test_<kernel_name>.py` (or append to existing test file if the repo groups tests by category) |
+| Performance benchmark | Discovered benchmark directory + `benchmark_<kernel_name>.py` (or append to existing benchmark file) |
+
+**Decision: separate file vs. append to existing?**
+- Use the Glob tool to check if the repo uses **one test file per operator** (e.g.,
+  `tests/test_relu.py`, `tests/test_softmax.py`) or **grouped test files** (e.g.,
+  `tests/test_unary_pointwise_ops.py`, `tests/test_reduction_ops.py`).
+- If grouped: use the Edit tool to append the new test to the appropriate existing file.
+- If per-operator: use the Write tool to create a new test file.
+- Apply the same logic for benchmarks.
+
+### 6c. Write the Kernel Implementation
+
+Use the Write tool (new file) or Edit tool (replacing existing) to create the operator file.
+
+The implementation should follow the exact pattern of similar operators in the repo. Include:
+- License header (if the repo uses one)
+- Imports matching repo style
+- Triton kernel function(s)
+- Python wrapper function(s)
+- Logging statements matching repo convention
+- In-place variants if applicable (verify pattern by reading an existing in-place op first)
+
+### 6d. Register the Operator (if applicable)
+
+If the repo has a registration mechanism, use the Edit tool to register the new operator.
+
+**First, discover the registration mechanism.** Not all repos use `__init__.py`. Search for:
+- `__init__.py` exports (most common)
+- Grep for `register_op`, `OP_REGISTRY`, `_dispatch_table`, `aten_map`, `_FULL_CONFIG` in
+  the discovered source directories — these are common registry patterns
+- `_custom_ops.py` or similar custom op registration files found in Step 2
+
+If a registration mechanism is found:
+1. **Read the registration file** first to understand the exact format.
+2. **Add the new entry in alphabetical order** — do not change existing entries.
+3. **Match the exact registration format** used by existing entries.
+
+If **no registration mechanism is found**, check one more thing before skipping:
+
+**Implicit import check**: If the operator source directory contains an `__init__.py` that
+imports other operators (e.g., `from .relu import *`, `from .softmax import softmax`), you
+MUST add a corresponding import line for the new operator. Otherwise the kernel file exists
+but the package cannot import it.
+
+```python
+# Example: src/pkg/ops/__init__.py already has:
+from .relu import relu
+from .softmax import softmax
+# → Add:
+from .<kernel_name> import <kernel_name>
+```
+
+If `__init__.py` does not exist or is empty, the kernel is standalone — skip registration.
+
+For **Option C (side-by-side variant)**: Do NOT register in the main dispatch mechanism. Only
+add to `__init__.py` for importability, not for aten/dispatch override.
+
+### 6e. Write the Accuracy Test
+
+Follow the test pattern discovered in Step 2c. Key conventions to match:
+- Parametrize decorators (shapes, dtypes, seeds, devices)
+- Reference implementation approach (pure PyTorch `ref_impl` vs `torch.<op>`)
+- Assertion method (`torch.testing.assert_close`, `gems_assert_close`, custom utils)
+- Per-dtype tolerances: fp32 → rtol/atol=1e-5, fp16 → 1e-2, bf16 → 2e-2
+- Test markers / decorators (`@pytest.mark.<kernel_name>`, `@torch.inference_mode()`, etc.)
+- Device handling (`flag_gems.device`, `"cuda"`, parametrized CUDA_DEVICES)
+- If the repo uses `to_reference()` or similar utilities, use them.
+
+If the repo registers pytest markers, add the new marker to the marker registration file
+(check `pytest.ini`, `pyproject.toml [tool.pytest.ini_options]`, or `setup.cfg`).
+
+### 6f. Write the Performance Benchmark
+
+Follow the benchmark pattern discovered in Step 2c. Key conventions to match:
+- Timing methodology (`triton.testing.do_bench_cudagraph`, `GenericBenchmark`, custom)
+- Reporting format (`triton.testing.perf_report`, print-based, etc.)
+- Configuration ranges (batch sizes, sequence lengths, hidden sizes)
+- Baseline comparison (always use `ref_impl` for the baseline, not `torch.<op>` which may
+  not exist for fused kernels)
+
+---
+
+## Step 6.5: Pre-test Validation
+
+Before running the full test suite, perform quick checks:
+
+### 6.5a. Lint / Format Check
+
+If the repo uses linting tools, run them on the changed files:
+
+```bash
+# Check which linter the repo uses
+# Look in pyproject.toml for [tool.ruff], [tool.black], [tool.isort], etc.
+```
+
+If found, run the linter on changed files to catch style issues early. If no linter is
+configured, skip this step.
+
+### 6.5b. Import Smoke Test
+
+Verify the new module can be imported:
+
+```bash
+python -c "from <module_path> import <kernel_name>; print('Import OK')"
+```
+
+### 6.5c. Triton Compile Smoke Test
+
+Run a minimal invocation to catch Triton compile errors early. **Build the smoke test call
+based on `arg_names` from Step 1** — do NOT hardcode a single-argument call.
+
+**Important**: Guard the device selection so the smoke test does not crash if CUDA is
+unavailable (even though Step 0 checked — the user may have chosen to proceed without GPU):
+
+```python
+import torch
+device = "cuda" if torch.cuda.is_available() else "cpu"
+```
+
+**If `device == "cpu"`**: Skip the Triton compile smoke test entirely. Triton kernels require
+CUDA and will crash with `RuntimeError` on CPU. Report to the user:
+```
+CUDA unavailable — skipping Triton compile test. The kernel will be compiled for the first time during the Step 7 accuracy tests.
+```
+Then proceed directly to Step 7.
+
+**If `device == "cuda"`**: construct the call based on `func_type` and `arg_names`.
+
+Then construct the call based on `func_type` and `arg_names`. **Use shapes inferred from the
+reference operator read in Step 2c.** If no reference shapes are available, use these fallbacks:
+
+```python
+# Fallback shapes by func_type:
+#   unary_pointwise / activation: (128,)
+#   binary_pointwise:             (128,)
+#   reduction:                    (32, 128)
+#   normalization:                (32, 128) + weight of shape (128,)
+#   attention:                    (1, 4, 8) for q/k/v
+#   blas:                         (32, 64) and (64, 32)
+
+# For unary ops (arg_names: ["x"]):
+x = torch.randn(128, device=device, dtype=torch.float16)
+out = kernel_fn(x)
+
+# For binary ops (arg_names: ["x", "y"]):
+x = torch.randn(128, device=device, dtype=torch.float16)
+y = torch.randn(128, device=device, dtype=torch.float16)
+out = kernel_fn(x, y)
+
+# For normalization ops (arg_names: ["x", "weight"]):
+x = torch.randn(32, 128, device=device, dtype=torch.float16)
+weight = torch.ones(128, device=device, dtype=torch.float16)
+out = kernel_fn(x, weight)
+
+# For attention ops (arg_names: ["q", "k", "v"]):
+q = torch.randn(1, 4, 8, device=device, dtype=torch.float16)
+k = torch.randn(1, 4, 8, device=device, dtype=torch.float16)
+v = torch.randn(1, 4, 8, device=device, dtype=torch.float16)
+out = kernel_fn(q, k, v)
+```
+
+**General rule**: create one small tensor for each entry in `arg_names`, matching the
+expected shapes for the `func_type`. Use `inspect.signature` to infer any missing arguments
+(e.g., `weight`, `bias`, `eps` for `layer_norm`) before constructing the smoke test, so that
+all required parameters are covered. If the smoke test fails, read the error and fix the
+kernel before proceeding.
+
+---
+
+## Step 7: Run Accuracy Tests
+
+Use the Bash tool to run accuracy tests.
+
+First, determine the correct invocation based on repo structure. **Prefer `pytest` over
+`python -m pytest`** because many repos depend on `conftest.py` discovery which works more
+reliably with direct `pytest` invocation:
+
+1. **Primary**: `pytest <test_path> -q` (use `-q` to minimize output and avoid token explosion;
+   only switch to `-v` if a test fails and you need detailed traceback)
+2. **Fallback** (if `pytest` command not found): `python -m pytest <test_path> -q`
+3. **If not pip-installed**: prepend `PYTHONPATH=.` to either command
+
+For grouped test files, use `-m <kernel_name>` or `-k <kernel_name>` to select only the
+new operator's tests.
+
+Report the results to the user. If tests fail, follow the **error classification and retry
+protocol** below. This protocol strictly limits self-fix attempts to prevent infinite loops.
+
+### Error Classification
+
+First, classify the error into one of two categories:
+
+**Category A — Compilation / Import errors** (model may attempt 1 self-fix):
+- `ImportError`, `ModuleNotFoundError` — wrong import path or missing module
+- `SyntaxError` — Python syntax issue
+- `TritonCompilationError`, `CompilationError` — Triton kernel compile failure
+- `NameError` — undefined variable or function
+- `TypeError` in function call signature — wrong number/type of arguments
+- `AttributeError` — wrong attribute access on a module or object
+
+**Category B — Algorithm / Numerical accuracy errors** (do NOT self-fix):
+- `AssertionError` from `torch.testing.assert_close` — numerical mismatch
+- Wrong output values (results don't match reference)
+- Shape mismatch in output tensors
+- NaN or Inf in output
+- Any error that indicates the kernel logic is incorrect
+
+### Retry Protocol (strictly follow this order)
+
+**Step 7a. (Category A only) Self-fix — maximum 1 attempt:**
+If the error is Category A (compilation/import), you may attempt exactly ONE fix:
+1. Read the error traceback carefully.
+2. Apply a targeted fix using the Edit tool (e.g., fix import path, fix syntax, fix argument name).
+3. Re-run the tests.
+4. If the test **passes** → proceed to Step 8.
+5. If the test **still fails** → proceed to Step 7b. Do NOT attempt a second self-fix.
+
+**If the error is Category B (algorithm/accuracy), skip Step 7a entirely** — go directly
+to Step 7b. Do NOT attempt to fix algorithm logic yourself, as this typically leads to
+an endless fix-retry loop without converging. The MCP service has better optimization
+capabilities for these issues.
+
+**Step 7b. MCP re-generation — pass error context to generate_operator:**
+Re-call `mcp__kernelgen-mcp__generate_operator` with the **same parameters as Step 5**,
+but add the error information to `flagos_wiki` as additional hints:
+```python
+flagos_wiki = [
+    # ... original flagos_wiki items from Step 4 ...
+    "Previous generation failed accuracy test: <brief error description>",
+    "Error was: <key line from traceback>",
+    "Fix hint: <your analysis>"
+]
+```
+Replace the kernel code with the new MCP output, re-run tests.
+- If tests **pass** → proceed to Step 8.
+- If tests **still fail** → proceed to Step 7c.
+
+**Step 7c. MCP optimization — pass error context to optimize_triton:**
+Try `mcp__kernelgen-mcp__optimize_triton` with the current kernel code and the
+`check_result` parameter containing the error traceback. This endpoint can fix
+memory access patterns, index calculations, and numerical issues.
+Replace the kernel code with the optimized output, re-run tests.
+- If tests **pass** → proceed to Step 8.
+- If tests **still fail** → proceed to Step 7d.
+
+**Step 7d. Stop and report:**
+Do not keep retrying. Report the failure to the user with:
+- The specific test failures and error messages
+- Your analysis of what might be wrong
+- Suggestion to try with different `func_type` or additional `flagos_wiki` hints
+
+---
+
+## Step 8: Run Performance Benchmark
+
+Use the Bash tool to run the benchmark.
+
+Determine invocation based on repo structure:
+- Standalone benchmark file: `python <benchmark_path>`
+- pytest-based benchmark: `python -m pytest <benchmark_path> -q -k "perf"`
+
+**Timeout**: Run the benchmark with a **120-second timeout**. If it exceeds this without
+completing, interrupt the process and report partial results to the user:
+```
+Benchmark exceeded 120 seconds without completing, interrupted. Partial output below:
+<partial output>
+For a full benchmark, please run manually: python <benchmark_path>
+```
+Some benchmarks (e.g., large sweep over sequence lengths / hidden sizes) can run for tens of
+minutes — the user should run these manually outside the skill.
+
+### Speedup Extraction
+
+Try to extract speedup metrics from the output:
+1. Look for explicit speedup with `x` suffix: `(\d+\.?\d*)x`
+2. Look for explicit `speedup` labels: `speedup.*?(\d+\.?\d*)`
+3. Look for paired timing values (triton vs torch): extract both and compute
+   `speedup = torch_latency / kernel_latency`
+4. Look for timing with units: `(\d+\.?\d*)\s*(us|ms|s)`
+
+**Fallback**: If latency values cannot be reliably parsed (e.g., output format is non-standard,
+or only raw numbers are printed), **report the raw benchmark output** to the user instead of
+attempting to compute speedup. Let the user interpret the results:
+
+```
+Benchmark completed, but speedup could not be automatically parsed. Raw output below:
+<raw output>
+```
+
+---
+
+## Step 9: Summary
+
+Provide a clear summary to the user with **exact numbers** extracted from test and benchmark
+output:
+
+```
+=== KernelGen Operator Generation Report ===
+
+Operator Name: <kernel_name>
+Target Repository: <project_name>
+Generation Mode: New / Replace Existing / Custom Variant (v2)
+Operator Type: <func_type>
+
+File Changes:
+  - [New/Modified] <kernel_file_path>           (Triton kernel)
+  - [Modified] <init_file_path>                   (Registration, if applicable)
+  - [New/Modified] <test_file_path>             (Accuracy Tests)
+  - [New/Modified] <benchmark_file_path>        (Performance Benchmark)
+
+Accuracy Tests: <N> passed, <M> failed (total <N+M> test cases)
+  Pass Rate: <N/(N+M)*100>%
+  Failed Cases: <list failed test names if any, or "None">
+
+Performance Benchmark:
+  Avg Speedup: <X.XX>x vs PyTorch reference
+  Best Speedup: <X.XX>x (config details)
+  Worst Speedup: <X.XX>x (config details)
+  (If benchmark was not run, failed, or could not be parsed, write "Incomplete" and explain the reason)
+
+MCP Iterations: <1, 2, or 3> (write 1 if first generation passed)
+
+Performance Analysis:
+  <Assess based on average speedup:
+   - Speedup > 5.0x → "Extreme fusion success, typical for fused multi-op kernels"
+   - Speedup > 3.0x → "Excellent compute-bound optimization, significant kernel fusion benefit"
+   - Speedup > 2.0x → "Compute-bound optimization effective, significant speedup achieved"
+   - Speedup 1.2x ~ 2.0x → "Moderate speedup, kernel likely balanced between compute and memory"
+   - Speedup 0.5x ~ 1.2x → "Kernel likely memory-bound, limited optimization headroom"
+   - Speedup < 0.5x → "Kernel slower than PyTorch reference — likely suboptimal memory access pattern"
+   - Unable to parse → Skip this section>
+
+Issues and Fixes: (if any)
+```
+
+**How to extract the numbers:**
+- **Pass/fail counts**: Parse pytest output for the line matching `X passed` or `X passed, Y failed`.
+  Use regex pattern `(\d+) passed` and `(\d+) failed` to extract.
+- **Speedup**: Parse benchmark output for kernel vs PyTorch time ratios. Calculate
+  `speedup = torch_time / kernel_time` for each config. Report min, max, and average.
+  - Use these regex patterns to extract timing values:
+    - `(\d+(?:\.\d+)?)\s*(us|ms|s)` — number with unit
+    - `(?i)mean:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — mean timing (pytest-benchmark format, e.g., `mean: 0.123 ms`)
+    - `(?i)avg:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — average timing value
+    - `(?i)median:\s*(\d+(?:\.\d+)?)\s*(us|ms|s)` — median timing value
+    - `(?i)(triton|kernel).*?(\d+(?:\.\d+)?)\s*(us|ms|s)` — kernel time
+    - `(?i)(torch|pytorch|reference).*?(\d+(?:\.\d+)?)\s*(us|ms|s)` — PyTorch reference time
+  - **Do not just copy the raw table** — always compute and report the actual speedup ratios.
+  - If parsing fails, report "Unable to parse" and include the raw output.
+
+**After presenting the summary, check the speedup:**
+
+- **If average speedup < 0.5x** (kernel slower than PyTorch), proactively warn the user:
+  ```
+  ⚠️ The currently generated Triton kernel performs worse than the PyTorch reference implementation.
+  This is typically caused by suboptimal memory access patterns or improper block size configuration.
+  Would you like to use /kernelgen_optimizer to optimize this kernel's performance?
+  ```
+
+- **If average speedup is 0.5x ~ 1.2x**, ask the user:
+  ```
+  Current speedup is low (<X.XX>x) and there may be room for optimization.
+  Would you like to use /kernelgen_optimizer to try improving performance?
+  ```
+
+- **If average speedup > 1.2x**, no action needed — report the result normally.
+
+---
+
+## Important Notes
+
+- **Dynamically discover everything** — never hardcode file paths or conventions. Always read
+  existing code first and follow the local patterns.
+- **Never overwrite existing operators** without explicit user permission (Step 3 choice).
+- **Always ask the user before installing packages** — never run `pip install` without confirmation.
+- **Match existing code style exactly** — imports, decorators, naming, logging, license headers.
+  The generated code must look like it was written by the same team.
+- **Use proper tools for all file operations**: Read to read files, Write to create new files,
+  Edit to modify existing files. Never use Write to overwrite an existing file — use Edit.
+- **Always run both accuracy AND performance tests** — don't stop at one.
+- **Use per-dtype tolerances** in tests: fp32 → 1e-5, fp16 → 1e-2, bf16 → 2e-2.
+- **Always use `ref_impl` for benchmark baselines**, not `torch.<op>` — many custom/fused
+  kernels have no single torch equivalent.
+- **Only rewrite to wrapper style when the repo explicitly uses wrappers**. Otherwise keep the
+  MCP-generated raw Triton code — this is the safer default.
+- **For raw Triton repos**: only add `@triton.autotune` if existing kernels use it. If the repo
+  does not use autotune, do NOT introduce it — use a fixed BLOCK_SIZE matching the repo pattern.
+- **Follow alphabetical ordering** when adding entries to `__init__.py`, `__all__`, or config lists.
+- If accuracy tests fail, try to fix. If benchmark is slow, consider calling
+  `mcp__kernelgen-mcp__optimize_triton` to optimize.
+- **Speedup formula**: `speedup = torch_latency / kernel_latency` (>1.0 means kernel is faster).
+  If parsing fails, report raw output instead.
+- **Never modify unrelated files**. Keep the diff minimal and focused.
+- **Use Chinese for user-facing messages** if the user communicates in Chinese.


### PR DESCRIPTION
## Summary

  - Add 4 KernelGen Claude Code skills that automate GPU kernel generation via the `kernelgen-mcp` MCP service: a general-purpose skill, two framework-specific skills (FlagGems, vLLM), and a feedback submission skill
  - Each generation skill implements a full 8-step pipeline: environment check → MCP availability → operator aliasing → code generation → file placement → accuracy testing → benchmarking → summary report
  - The feedback skill provides a structured GitHub issue workflow for reporting bugs and improvements

  ## Skills

  | Skill | Description | SKILL.md |
  |-------|-------------|----------|
  | `kernelgen` | General-purpose GPU kernel generation for any Python/Triton project | 971 lines |
  | `kernelgen-for-flaggems` | FlagGems-specific generation with promotion rules, `pointwise_dynamic` wrappers, and `_FULL_CONFIG` registration | 882 lines |
  | `kernelgen-for-vllm` | vLLM-specific generation with SPDX headers, `vllm.logger`, `@triton.autotune`, and custom op registration | 1020 lines |
  | `kernelgen-submit-feedback` | Submit bug reports / improvement suggestions as GitHub issues to flagos-ai/skills | 435 lines |

  ## Key Techniques

  | Technique | Description |
  |-----------|-------------|
  | MCP-driven code generation | Calls `mcp__kernelgen-mcp__generate_operator` and `mcp__kernelgen-mcp__optimize_triton` to produce Triton kernel code, avoiding hand-written GPU code entirely |
  | Operator alias resolution | 13-entry alias table normalizes natural-language operator names (e.g., `square_root → sqrt`, `cube → pow (exp=3)`) before MCP calls |
  | `func_type` auto-inference | Pattern-based rules infer kernel category (activation, norm, attention, quantization, etc.) from the operator name, reducing user input |
  | Multi-pass error recovery | 4-step retry protocol: self-fix → MCP re-generate → MCP optimize with error context → stop and report. Strictly bounded to prevent infinite loops |
  | `inspect.signature` smoke test | Introspects the generated kernel's function signature to infer missing arguments (weight, bias, eps) before constructing smoke tests |
  | Benchmark regex extraction | 6 regex patterns extract timing values from diverse benchmark output formats (mean, avg, median, raw units, Triton-specific, PyTorch reference) |
  | MCP prerequisite check | If `kernelgen-mcp` is not configured, directs users to https://kernelgen.flagos.io/ for setup instructions |

  ## Files

  skills/kernelgen/
  ├── SKILL.md, README.md, README_zh.md, LICENSE.txt

  skills/kernelgen-for-flaggems/
  ├── SKILL.md, README.md, README_zh.md, LICENSE.txt

  skills/kernelgen-for-vllm/
  ├── SKILL.md, README.md, README_zh.md, LICENSE.txt

  skills/kernelgen-submit-feedback/
  ├── SKILL.md, README.md, README_zh.md, LICENSE.txt
