### PR TITLE
Add -flagos suffix validation to validate_skills.py

### DIFF
--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -127,6 +127,11 @@ def validate_skill(skill_dir: Path) -> tuple[list[str], list[str]]:
             errors.append(
                 f"{skill_dir.name}: name '{name}' does not match directory name"
             )
+        if not name.endswith("-flagos"):
+            errors.append(
+                f"{skill_dir.name}: name '{name}' must end with '-flagos' suffix "
+                f"(e.g., '{name}-flagos')"
+            )
 
     # Validate description
     desc = fields.get("description", "")


### PR DESCRIPTION
## Summary
- Adds a check in `validate_skills.py` that enforces skill names must end with the `-flagos` suffix
- Validation fails with a clear message when the suffix is missing, e.g.: `name 'my-skill' must end with '-flagos' suffix (e.g., 'my-skill-flagos')`
- All existing skills (model-migrate-flagos, skill-creator-flagos, kernelgen-flagos) already pass this check

## Test plan
- [x] Run `python3 scripts/validate_skills.py` — all current skills should pass
- [x] Create a test skill without `-flagos` suffix — validation should fail with helpful message