### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate-skills:
+    name: Validate Skills
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run skill validation
+        run: python3 scripts/validate_skills.py
+
+  # ── Add future check jobs below ──────────────────────────
+  # Example:
+  #
+  # lint-markdown:
+  #   name: Lint Markdown
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Run markdownlint
+  #       uses: DavidAnson/markdownlint-cli2-action@v19
+  #       with:
+  #         globs: "skills/**/*.md"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with a `validate-skills` job
- Triggers on every push to `main` and all PRs targeting `main`
- Uses GitHub-hosted runner (`ubuntu-latest`) + Python 3.11
- Structured as independent jobs for easy extension (e.g., markdown lint, link checking)

## Test plan
- [ ] Verify the CI workflow triggers on this PR
- [ ] Confirm `validate_skills.py` runs and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)