### PR TITLE
Test: add skill-test without -flagos suffix

### DIFF
--- a/skills/skill-test/SKILL.md
+++ b/skills/skill-test/SKILL.md
@@ -5,7 +5,7 @@ description: A test skill for CI validation testing purposes
 
 # Skill Test
 
-This is a test skill created to verify that the CI validation pipeline catches naming violations.
+This is a test skill created to verify that the CI validation pipeline correctly catches naming violations.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Adds a test skill `skill-test` that intentionally violates validation rules
- **Expected CI failures:**
  - name `skill-test` missing `-flagos` suffix
  - no `LICENSE.txt`
  - no `README.md`

This PR is for testing CI validation — do NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)