### PR TITLE
fix: align SKILL.md name fields with directory names

### DIFF
--- a/skills/flagrelease-entrance-flagos/SKILL.md
+++ b/skills/flagrelease-entrance-flagos/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: flagrelease
+name: flagrelease-entrance-flagos
 description: |
   Full FlagRelease pipeline orchestrator. Runs the complete LLM deployment, verification,
   and benchmarking pipeline for multi-chip GPU backends. Executes: install-stack →

--- a/skills/gpu-container-setup-flagos/SKILL.md
+++ b/skills/gpu-container-setup-flagos/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: gpu-container-setup
+name: gpu-container-setup-flagos
 description: |
   Automatically detect GPU vendor, find appropriate PyTorch container image,
   launch with correct mounts, and validate GPU functionality. Supports NVIDIA,

--- a/skills/install-stack-flagos/SKILL.md
+++ b/skills/install-stack-flagos/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: install-stack
+name: install-stack-flagos
 description: |
   Install the 5-package multi-chip software stack (vLLM, FlagTree, FlagGems, FlagCX,
   vllm-plugin-FL) inside a GPU container. Handles network mirror detection, dependency

--- a/skills/model-verify-flagos/SKILL.md
+++ b/skills/model-verify-flagos/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: model-verify
+name: model-verify-flagos
 description: |
   Verify the serving stack with a user-specified target model. Runs twice: first with
   FlagGems/FlagCX disabled (isolate model-specific errors), then with full multi-chip

--- a/skills/perf-test-flagos/SKILL.md
+++ b/skills/perf-test-flagos/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: perf-test
+name: perf-test-flagos
 description: |
   Run accuracy benchmarks (FlagEval, when available) and performance benchmarks
   (vllm bench serve) against a served model. Covers 5 workload profiles: short/long


### PR DESCRIPTION
## Summary

- Fixed 5 SKILL.md files where the `name` field was missing the `-flagos` suffix

## Problem

According to the [Agent Skills standard](https://agentskills.io/specification), the `name` field in SKILL.md must match the directory name. This was inconsistent in 5 skills:

| Directory | SKILL.md name (before) | SKILL.md name (after) |
|-----------|------------------------|------------------------|
| `flagrelease-entrance-flagos` | `flagrelease` | `flagrelease-entrance-flagos` |
| `gpu-container-setup-flagos` | `gpu-container-setup` | `gpu-container-setup-flagos` |
| `install-stack-flagos` | `install-stack` | `install-stack-flagos` |
| `model-verify-flagos` | `model-verify` | `model-verify-flagos` |
| `perf-test-flagos` | `perf-test` | `perf-test-flagos` |

## Impact

Without this fix:
- `npx skills add flagos-ai/skills --skill gpu-container-setup-flagos` may fail to find the skill
- `/<skill-name>` slash commands may not work correctly

## Test Results

✅ All 9 skills pass `python scripts/validate_skills.py`:
```
Summary: 9 skill(s), 0 error(s), 33 warning(s)
```

✅ Directory name and `name` field now match for all skills:
```
✓ flagrelease-entrance-flagos
✓ gpu-container-setup-flagos
✓ install-stack-flagos
✓ kernelgen-flagos
✓ model-migrate-flagos
✓ model-verify-flagos
✓ perf-test-flagos
✓ skill-creator-flagos
✓ tle-developer-flagos
```

✅ Installation test passed:
```bash
npx skills add /tmp/skills --skill gpu-container-setup-flagos --yes
# ✓ Installed 1 skill: gpu-container-setup-flagos
```

## Test plan

- [x] Run `python scripts/validate_skills.py` - all pass
- [x] Verify directory names match `name` fields
- [x] Test `npx skills add --skill <skill-name>` installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)