### PR TITLE
docs(kernelgen-flagos): add MCP service prerequisite to installation section

### DIFF
--- a/skills/kernelgen-flagos/README.md
+++ b/skills/kernelgen-flagos/README.md
@@ -149,6 +149,10 @@ Combines MCP platform specialization with FlagGems framework integration. Suppor
 
 ## Usage in FlagOS Skills Repository
 
+### Prerequisites
+
+This skill depends on the `kernelgen-mcp` MCP service for operator generation and optimization. Make sure it is properly installed and configured before use.
+
 ### Quick Install (via npx)
 
 ```bash

--- a/skills/kernelgen-flagos/README_zh.md
+++ b/skills/kernelgen-flagos/README_zh.md
@@ -103,6 +103,10 @@ skills/kernelgen-flagos/
 
 ## 安装方式
 
+### 前置依赖
+
+本技能依赖 `kernelgen-mcp` MCP 服务进行算子生成与优化，请确保在使用前已正确安装并配置该 MCP 服务。
+
 ### 快速安装（通过 npx）
 
 ```bash


### PR DESCRIPTION
在 README.md 和 README_zh.md 的安装方式部分添加了 `kernelgen-mcp` MCP 服务的前置依赖说明，提示用户在使用技能前需要先安装并配置该 MCP 服务。