### PR TITLE
vllm-upgrade-flagos skill: Add post-migration performance benchmark & API change patterns   

### DIFF
--- a/skills/vllm-upgrade-flagos/README_zh.md
+++ b/skills/vllm-upgrade-flagos/README_zh.md
@@ -117,8 +117,10 @@ conda activate vllm_plugin_update && bash scripts/benchmark.sh Qwen3.5-397B-A17B
 | 基类方法缺失调用 | `import_kernels()` 未调用 `super()` | 添加 `super()` 调用 |
 | OOT 注册门控 | FlagGems 门控阻止注册 | 移除不必要的门控 |
 | 返回值语义变更 | runner 自行处理 shared experts | 调整返回值（不返回 tuple） |
-| `_custom_ops` 函数移除 | `from vllm._custom_ops import silu_and_mul` → 移除 | 改用 `torch.ops._C.silu_and_mul` |
+| `_custom_ops` 函数移除 | `from vllm._custom_ops import silu_and_mul` → 移除 | 改用 `torch.ops._C.<fn>`，逐个检查上游 `_custom_ops.py` |
 | 工具函数移除 | `from vllm.utils.import_utils import init_cached_hf_modules` → 移除 | 删除相关调用 |
+
+> 注：平台特定的修复（如 CUDA kernel 路径）应在代码中用行内注释标注，不在此文档中列出。本技能保持平台无关。
 
 ---
 

--- a/skills/vllm-upgrade-flagos/README_zh.md
+++ b/skills/vllm-upgrade-flagos/README_zh.md
@@ -1,0 +1,195 @@
+# vllm-upgrade-flagos：vLLM 插件版本升级工具
+
+## 概述
+
+`vllm-upgrade-flagos` 用于将 vllm-plugin-FL 插件的基础设施代码升级到匹配更新版本的上游 vLLM。
+
+### 解决的问题
+
+vllm-plugin-FL 是一个 OOT（out-of-tree）插件，覆盖或扩展了 vLLM 的 worker、model_runner、platform、compilation 和 ops 子系统。当上游 vLLM 版本升级时，内部 API 会发生变化（类重命名、函数签名变更、模块重组等），插件代码必须同步更新。
+
+手动升级涉及大量工作：对比 API 差异、逐文件适配、处理废弃代码、清理已上游化的模型。本技能将整个流程自动化为 11 个步骤，确保升级过程可重复、不遗漏。
+
+### 使用方式
+
+```bash
+# 默认路径
+/vllm-upgrade-flagos
+
+# 指定路径
+/vllm-upgrade-flagos /path/to/upstream/vllm /path/to/vllm-plugin-FL
+```
+
+| 参数 | 必填 | 默认值 | 说明 |
+|---|---|---|---|
+| `upstream_folder` | 否 | `/workspace/vllm_update/vllm` | 上游 vLLM 源码目录 |
+| `plugin_folder` | 否 | `/workspace/vllm_update/vllm-plugin-FL` | 插件源码目录 |
+
+---
+
+## 升级流程
+
+### 步骤 1：基线单元测试
+
+在修改任何代码之前，运行插件现有的单元测试，记录基线结果。
+
+### 步骤 2：API 差异分析
+
+对比插件基础设施文件与上游对应文件之间的 API 变化：
+- 度量变更范围（commit 数、diff 统计）
+- 提取插件自定义代码（dispatch、IO dumper、FL envs 等）
+- 识别需要适配的 API 变更
+
+### 步骤 3–7：逐模块升级
+
+按以下顺序升级插件基础设施：
+
+| 顺序 | 插件文件 | 上游对应 | 说明 |
+|---|---|---|---|
+| 3 | `vllm_fl/platform.py` | `vllm/platforms/interface.py` + `cuda.py` | 平台抽象层 |
+| 4 | `vllm_fl/compilation/graph.py` | `vllm/compilation/cuda_graph.py` | CUDA 图封装 |
+| 5 | `vllm_fl/worker/worker.py` | `vllm/v1/worker/gpu_worker.py` | GPU Worker |
+| 6 | `vllm_fl/worker/model_runner.py` | `vllm/v1/worker/gpu_model_runner.py` | 模型运行器 |
+| 7 | `vllm_fl/ops/` | `vllm/model_executor/layers/` | 算子层（MoE、激活、LayerNorm 等） |
+
+每个模块的升级策略：
+1. 从上游复制最新版本
+2. 重新注入插件自定义代码
+3. 修复导入路径和 API 签名
+4. 验证导入通过
+
+### 步骤 8：清理废弃代码
+
+**不是盲目删除所有文件**，而是逐一检查：
+
+- **模型文件**（`models/`）：检查上游是否已有对应模型类和注册。已上游化且插件不再注册的 → 删除
+- **配置文件**（`configs/`）：检查上游 `_CONFIG_REGISTRY` 是否已包含对应 `model_type`。已上游化且无其他引用的 → 删除
+- **补丁文件**（`patches/`）：检查补丁修复的问题是否已在上游解决。仍需要的 → 保留
+
+删除后验证无悬空导入：
+
+```bash
+grep -rn 'from vllm_fl\.models\.\|from vllm_fl\.configs\.\|from vllm_fl\.patches\.' \
+  vllm_fl/ --include='*.py' | grep -v __pycache__
+```
+
+### 步骤 9：清理 `__init__.py`
+
+- 移除已上游化模型/配置的注册代码
+- 如果 `register_model()` 仍有未上游化的注册项 → 保留函数
+- 如果 `register_model()` 完全为空 → 删除函数
+- 移除已删除补丁的导入和调用
+
+### 步骤 10：验证与回归测试
+
+五级验证：
+
+1. **导入验证** — 确认所有插件模块可正常导入
+2. **端到端推理** — 运行 `qwen3_5_offline_inference.py`，验证完整推理链路
+3. **回归单元测试** — 与步骤 1 基线对比
+4. **功能测试** — 运行功能测试套件
+5. **性能基准测试** — 运行吞吐量基准，检测性能回退
+
+性能测试使用 `scripts/benchmark.sh`：
+
+```bash
+conda activate vllm_plugin_update && bash scripts/benchmark.sh Qwen3.5-397B-A17B-Real
+```
+
+测试参数：100 条 prompt，input_len=6144，output_len=1024，TP=4，dummy 权重。
+关注指标：吞吐量（tokens/s）、首 token 延迟（TTFT）、无 OOM/CUDA 错误。
+
+### 步骤 11：更新版本引用
+
+更新文件头注释、`pyproject.toml` 版本约束等。
+
+---
+
+## 常见 API 变更模式
+
+本技能在升级过程中会自动处理以下常见变更：
+
+| 变更类型 | 示例 | 处理方式 |
+|---|---|---|
+| 环境变量重命名/移除 | `VLLM_FUSED_MOE_CHUNK_SIZE` → 移除 | 替换为硬编码默认值或新变量名 |
+| 字符串→枚举 | `activation="silu"` → `MoEActivation.SILU` | 添加枚举值归一化 |
+| 函数签名变更 | `forward_native` 新增参数 | 更新方法签名匹配上游 |
+| 基类方法缺失调用 | `import_kernels()` 未调用 `super()` | 添加 `super()` 调用 |
+| OOT 注册门控 | FlagGems 门控阻止注册 | 移除不必要的门控 |
+| 返回值语义变更 | runner 自行处理 shared experts | 调整返回值（不返回 tuple） |
+| `_custom_ops` 函数移除 | `from vllm._custom_ops import silu_and_mul` → 移除 | 改用 `torch.ops._C.silu_and_mul` |
+| 工具函数移除 | `from vllm.utils.import_utils import init_cached_hf_modules` → 移除 | 删除相关调用 |
+
+---
+
+## 插件基础设施架构
+
+```
+vllm-plugin-FL/
+├── vllm_fl/
+│   ├── __init__.py          # 插件入口：register() + register_model()
+│   ├── platform.py          # 平台抽象（设备检测、内核加载、配置）
+│   ├── compilation/
+│   │   └── graph.py         # CUDA 图封装
+│   ├── worker/
+│   │   ├── worker.py        # GPU Worker（初始化、KV 缓存、执行循环）
+│   │   └── model_runner.py  # 模型运行器（加载、前向、采样）
+│   ├── ops/
+│   │   ├── custom_ops.py    # OOT 算子注册
+│   │   ├── activation.py    # 激活函数
+│   │   ├── layernorm.py     # LayerNorm
+│   │   ├── rotary_embedding.py  # 旋转位置编码
+│   │   └── fused_moe/       # MoE 算子
+│   │       ├── layer.py     # FusedMoE 层 + UnquantizedFusedMoEMethod
+│   │       └── fused_moe.py # MoE 内核实现
+│   ├── dispatch/             # 算子分发框架（保留不动）
+│   ├── configs/              # 未上游化的模型配置
+│   ├── patches/              # 兼容性补丁
+│   └── models/               # 未上游化的模型（升级后通常为空）
+```
+
+---
+
+## Conda 环境
+
+| 环境 | 用途 |
+|---|---|
+| `vllm_plugin_update` | 目标环境 — 安装了新版 vLLM，所有验证和测试在此运行 |
+| `vllm_0.13.0_plugin_tree` | 旧环境 — vLLM v0.13.0 + 当前插件，用于对比旧 API |
+
+---
+
+## 故障排查
+
+| 问题 | 常见原因 | 解决方式 |
+|---|---|---|
+| `ImportError: cannot import name X from vllm` | API 在新版本中重命名或移动 | 查看 `api-changes.md`，更新导入路径 |
+| `TypeError: __init__() got unexpected keyword` | 构造函数签名变更 | 对比上游类签名，更新调用 |
+| `AttributeError: module has no attribute X` | 模块重组 | 检查上游模块布局，更新导入 |
+| Worker 初始化崩溃 | 新增必填配置字段或初始化步骤 | 对比上游 worker `__init__` |
+| CUDA 图捕获失败 | CUDAGraphWrapper API 变更 | 检查 compilation 变更，更新 `graph.py` |
+| `assert self.kernel is not None` | OOT 类未注册，回退到基类 `forward_cuda` | 检查 `custom_ops.py` 注册逻辑 |
+| `pip install -e .` 覆盖 vLLM | 插件拉取 vLLM 作为依赖 | 始终使用 `pip install --no-build-isolation --no-deps -e .` |
+
+---
+
+## 安装
+
+### 通过 skills CLI
+
+```bash
+npx skills add flagos-ai/skills --skill vllm-upgrade-flagos -a claude-code
+```
+
+### 手动安装
+
+```bash
+mkdir -p .claude/skills
+ln -s <本仓库路径>/skills/vllm-upgrade-flagos .claude/skills/
+```
+
+---
+
+## 许可证
+
+This project is licensed under the Apache 2.0 License.

--- a/skills/vllm-upgrade-flagos/SKILL.md
+++ b/skills/vllm-upgrade-flagos/SKILL.md
@@ -109,6 +109,11 @@ the file was adopted from.
 
 When upgrading, these customizations must be preserved and adapted to the new API.
 
+**Do NOT replace `current_platform.torch_device_fn.*` with `torch.cuda.*`.** The plugin supports
+multiple backends (NVIDIA CUDA, Ascend NPU, MetaX MACA, etc.). `torch_device_fn` is the platform
+abstraction that routes to the correct device API at runtime. Hardcoding `torch.cuda.*` breaks
+non-CUDA platforms.
+
 **Delete all model code.** After upgrading to v0.18+, all models are natively supported upstream.
 The plugin no longer needs to carry any model-specific code. Delete entirely:
 - All model files in `vllm_fl/models/`

--- a/skills/vllm-upgrade-flagos/SKILL.md
+++ b/skills/vllm-upgrade-flagos/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: vllm-upgrade-flagos
+description: >
+  Upgrade the vllm-plugin-FL plugin's infrastructure code to match a newer upstream vLLM version.
+  This skill handles upgrading core components like worker, model_runner, platform, compilation,
+  ops, and dispatch — plus cleaning up model/config code that is now natively supported upstream.
+  Use this skill whenever someone wants to upgrade the plugin's vLLM base version, sync the plugin
+  with a newer vLLM release, update the plugin's worker or model_runner, or bump the vLLM pin.
+  Trigger when the user says things like "upgrade plugin to vLLM 0.18", "sync plugin with upstream
+  vLLM", "update vllm-plugin-FL base version", "bump vLLM version for the plugin", or simply
+  "/vllm-upgrade-flagos".
+argument-hint: "[upstream_folder] [plugin_folder]"
+user-invocable: true
+compatibility: "Requires vLLM source (upstream), vllm-plugin-FL source, Python 3.10+, Linux"
+metadata:
+  version: "1.0.0"
+  author: flagos-ai
+  category: workflow-automation
+  tags: [vllm, upgrade, plugin, infrastructure, version-bump]
+allowed-tools: "Bash(pytest:*) Bash(python3:*) Bash(git:*) Bash(diff:*) Bash(cp:*) Bash(grep:*) Bash(find:*) Bash(wc:*) Bash(head:*) Bash(tail:*) Bash(cat:*) Bash(ls:*) Bash(pip:*) Bash(cd:*) Bash(mkdir:*) Bash(bash:*) Bash(test:*) Read Edit Write Glob Grep AskUserQuestion TaskCreate TaskUpdate TaskList TaskGet"
+---
+
+# FL Plugin — vLLM Version Upgrade Skill
+
+## Usage
+
+```
+/vllm-upgrade-flagos [upstream_folder] [plugin_folder]
+```
+
+| Argument | Required | Default |
+|---|---|---|
+| `upstream_folder` | No | `/workspace/vllm_update/vllm` |
+| `plugin_folder` | No | `/workspace/vllm_update/vllm-plugin-FL` |
+
+## Overview
+
+This skill upgrades the vllm-plugin-FL plugin's **infrastructure layer** to be compatible with a
+newer upstream vLLM version. The plugin is an out-of-tree (OOT) extension that overrides or extends
+vLLM's worker, model_runner, platform, compilation, and ops subsystems. When vLLM's internal APIs
+change between versions, the plugin code must be updated to match.
+
+After upgrading to a newer vLLM version, models that were previously only available via the plugin
+may now be natively supported upstream. In that case, the plugin's model files, config bridges, and
+registration code should be cleaned up — the plugin no longer needs to carry them.
+
+## Execution
+
+### Step 1: Parse arguments and detect versions
+
+Extract from user input:
+- `{{upstream_folder}}` = first argument or `/workspace/vllm_update/vllm`
+- `{{plugin_folder}}` = second argument or `/workspace/vllm_update/vllm-plugin-FL`
+
+Detect current state:
+```bash
+# Upstream vLLM version
+cd {{upstream_folder}} && git describe --tags 2>/dev/null || git log --oneline -1
+
+# Verify target env vLLM version
+conda activate vllm_plugin_update && python3 -c "import vllm; print(vllm.__version__)"
+
+# Current plugin base version (check comments in worker/model_runner files)
+head -5 {{plugin_folder}}/vllm_fl/worker/model_runner.py
+head -5 {{plugin_folder}}/vllm_fl/worker/worker.py
+```
+
+Report detected versions (current plugin base → target upstream) to the user.
+
+### Step 2: Load references and create task list
+
+Read these files (relative to this SKILL.md):
+- `references/procedure.md` — step-by-step upgrade procedure
+- `references/api-changes.md` — known API changes between vLLM versions
+- `references/operational-rules.md` — communication, TaskList, bash rules
+
+Then create the full TaskList per `operational-rules.md`.
+
+### Step 3–11: Follow procedure.md
+
+The detailed upgrade procedure is in `references/procedure.md`. It covers:
+
+1. Baseline tests
+2. API diff analysis (upstream vs plugin)
+3. Platform upgrade
+4. Compilation/graph upgrade
+5. Worker upgrade
+6. Model runner upgrade
+7. Ops layer upgrade
+8. Delete all model/config/patch code (now upstream)
+9. Clean up __init__.py (remove register_model, model patches)
+10. Import verification, offline inference end-to-end test & regression tests
+11. Final report
+
+## Key Principles
+
+**Copy-then-patch, not rewrite.** Copy the upstream file, then apply plugin-specific patches
+(dispatch hooks, custom ops, FL platform logic). This makes future upgrades easier because you
+can diff against the upstream version. Always add a header comment noting which upstream version
+the file was adopted from.
+
+**Preserve plugin customizations.** The plugin adds significant custom logic on top of vLLM:
+- Dispatch system (`vllm_fl/dispatch/`) — routes ops to different backends (FlagGems, CUDA, Ascend)
+- Custom ops (`vllm_fl/ops/`) — activation, layernorm, rotary, fused_moe, fla
+- Platform abstraction (`vllm_fl/platform.py`) — multi-chip support
+- Compilation hooks (`vllm_fl/compilation/`) — custom graph capture
+- IO dumping (`vllm_fl/dispatch/io_dumper.py`, `io_common.py`) — inference debugging
+- FL envs (`vllm_fl/envs.py`) — plugin-specific environment variables
+
+When upgrading, these customizations must be preserved and adapted to the new API.
+
+**Delete all model code.** After upgrading to v0.18+, all models are natively supported upstream.
+The plugin no longer needs to carry any model-specific code. Delete entirely:
+- All model files in `vllm_fl/models/`
+- All config bridges in `vllm_fl/configs/` (keep `__init__.py` empty)
+- All patches in `vllm_fl/patches/` (keep `__init__.py` empty)
+- The entire `register_model()` function in `vllm_fl/__init__.py`
+- Any model-specific patch calls in `register()` (e.g. `glm_moe_dsa` platform patches)
+
+**Incremental verification.** After each major component upgrade, run import checks before
+moving to the next component. Don't upgrade everything at once.
+
+**Upstream-first debugging.** When something breaks, first compare the upstream code with the
+plugin adaptation. The diff is the fastest path to root cause.
+
+## Component Dependency Order
+
+Upgrade components in this order (each depends on the previous):
+
+```
+1. platform.py          (foundation — device detection, capabilities)
+2. compilation/         (graph capture, CUDA graph wrappers)
+3. worker/worker.py     (process management, initialization)
+4. worker/model_runner.py (model execution — the largest and most complex file)
+5. ops/                 (custom operators — may need new signatures)
+6. __init__.py          (remove register_model, model patches)
+7. models/ + configs/ + patches/  (delete all — now upstream)
+```
+
+## Identifying Plugin Customizations
+
+Before overwriting a plugin file with the upstream version, extract the plugin-specific additions.
+These are the lines that exist in the plugin but NOT in the upstream counterpart. Common patterns:
+
+```python
+# FL-specific imports
+from vllm_fl.ops.custom_ops import register_oot_ops
+from vllm_fl.dispatch.io_common import managed_inference_mode
+from vllm_fl.utils import get_flag_gems_whitelist_blacklist
+import vllm_fl.envs as fl_envs
+
+# FL-specific initialization
+register_oot_ops()
+managed_inference_mode(...)
+get_flag_gems_whitelist_blacklist(...)
+
+# FL-specific compilation hooks
+from vllm_fl.compilation.graph import FLGraphWrapper  # replaces CUDAGraphWrapper
+
+# FL-specific platform checks
+from vllm_fl.platform import PlatformFL
+```
+
+Use `diff` to identify these before starting the copy-then-patch process.
+
+## Examples
+
+**Example 1: Full upgrade from v0.13.0 to v0.18+**
+```
+User: "upgrade plugin to match the latest vLLM"
+Actions:
+  1. Detect: plugin based on v0.13.0, upstream at v0.18.1
+  2. API diff: identify changed imports, new classes, removed APIs
+  3. Upgrade platform.py, compilation/graph.py, worker.py, model_runner.py
+  4. Upgrade ops layer
+  5. Clean dead model/config/patch code — check what's upstream before deleting
+  6. Clean up __init__.py — remove obsolete registrations
+  7. Verify imports, run tests
+  8. Run performance benchmark: bash scripts/benchmark.sh Qwen3.5-397B-A17B-Real
+Result: plugin infrastructure upgraded, dead code cleaned, performance verified
+```
+
+**Example 2: Incremental sync after upstream minor bump**
+```
+User: "upstream vLLM updated from 0.18.0 to 0.18.1, sync plugin"
+Actions:
+  1. Detect: small version bump, few API changes
+  2. Diff only changed files between versions
+  3. Apply targeted patches to affected plugin files
+  4. Verify, test, and benchmark
+Result: plugin synced with minor upstream changes
+```
+
+## Troubleshooting
+
+| Problem | Typical Cause | Fix |
+|---|---|---|
+| `ImportError: cannot import name X from vllm` | API renamed or moved in new version | Check `api-changes.md`; update import path |
+| `TypeError: __init__() got unexpected keyword` | Constructor signature changed | Compare upstream class signature; update call site |
+| `AttributeError: module has no attribute X` | Module restructured | Check upstream module layout; update import |
+| Worker crashes on init | New required config fields or init steps | Compare upstream worker `__init__` with plugin |
+| CUDA graph capture fails | CUDAGraphWrapper API changed | Check compilation changes; update `graph.py` |
+| `pip install -e .` overwrites vLLM | Plugin pulls vLLM as dependency | Always use `pip install --no-build-isolation --no-deps -e .` |

--- a/skills/vllm-upgrade-flagos/references/api-changes.md
+++ b/skills/vllm-upgrade-flagos/references/api-changes.md
@@ -1,0 +1,310 @@
+# Known API Changes: vLLM v0.13.0 → v0.18+
+
+This catalog documents breaking API changes between vLLM versions that affect the plugin's
+infrastructure code. When upgrading, check each change against the plugin files.
+
+---
+
+## AC1: Attention Layer Import Path Change
+
+**Versions**: v0.14+
+
+```python
+# v0.13.0
+from vllm.attention.layer import Attention, MLAAttention
+
+# v0.18+
+from vllm.model_executor.layers.attention import Attention, MLAAttention
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+```
+
+**Affected**: `model_runner.py`
+
+---
+
+## AC2: CUDAGraphWrapper Moved
+
+**Versions**: v0.15+
+
+```python
+# v0.13.0
+from vllm.compilation.cuda_graph import CUDAGraphStat  # CUDAGraphWrapper in same file
+
+# v0.18+
+from vllm.compilation.cuda_graph import CUDAGraphStat, CUDAGraphWrapper
+```
+
+**Affected**: `model_runner.py`, `compilation/graph.py`
+
+---
+
+## AC3: set_forward_context Replaces get_forward_context
+
+**Versions**: v0.15+
+
+```python
+# v0.13.0
+from vllm.forward_context import BatchDescriptor, get_forward_context
+
+# v0.18+
+from vllm.forward_context import BatchDescriptor, set_forward_context
+```
+
+**Affected**: `model_runner.py`
+
+---
+
+## AC4: CompilationMode Import Path
+
+**Versions**: v0.14+
+
+```python
+# v0.13.0
+from vllm.config.compilation import CompilationMode
+
+# v0.18+ (may be merged into vllm.config)
+from vllm.config import CompilationMode
+```
+
+**Affected**: `worker.py`, `model_runner.py`
+
+---
+
+## AC5: set_current_vllm_config Added
+
+**Versions**: v0.15+
+
+```python
+# v0.18+
+from vllm.config import set_current_vllm_config
+```
+
+New function used in model runner initialization. May need to be called in plugin's model runner.
+
+**Affected**: `model_runner.py`
+
+---
+
+## AC6: RoutedExpertsCapturer Added
+
+**Versions**: v0.16+
+
+```python
+# v0.18+
+from vllm.model_executor.layers.fused_moe.routed_experts_capturer import RoutedExpertsCapturer
+```
+
+New class for MoE CUDA graph capture. Plugin's fused_moe layer may need to integrate.
+
+**Affected**: `model_runner.py`, `ops/fused_moe/layer.py`
+
+---
+
+## AC7: Model Offloader API
+
+**Versions**: v0.16+
+
+```python
+# v0.18+
+from vllm.model_executor.offloader import create_offloader, get_offloader, set_offloader
+```
+
+New model offloading system. Plugin worker/model_runner may need to support it.
+
+**Affected**: `model_runner.py`
+
+---
+
+## AC8: Worker Base Class Changes
+
+**Versions**: v0.14+
+
+```python
+# v0.13.0
+from vllm.v1.worker.worker_base import WorkerBase
+
+# v0.18+ — WorkerBase may have new abstract methods
+```
+
+Check for new abstract methods that the plugin's Worker class must implement.
+
+**Affected**: `worker.py`
+
+---
+
+## AC9: KVCacheConfig / KVCacheSpec Changes
+
+**Versions**: v0.15+
+
+The KV cache interface may have new fields or changed method signatures. Check:
+- `vllm/v1/kv_cache_interface.py`
+- Worker's `determine_available_memory()` and `initialize_cache()` methods
+
+**Affected**: `worker.py`
+
+---
+
+## AC10: SchedulerOutput Changes
+
+**Versions**: v0.14+
+
+```python
+# v0.13.0
+from vllm.v1.core.sched.output import SchedulerOutput
+
+# v0.18+ — may have new fields (GrammarOutput, etc.)
+from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
+```
+
+**Affected**: `worker.py`, `model_runner.py`
+
+---
+
+## AC11: ModelRunnerOutput Changes
+
+**Versions**: v0.15+
+
+```python
+# v0.13.0
+from vllm.v1.outputs import ModelRunnerOutput
+
+# v0.18+ — new output types
+from vllm.v1.outputs import AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
+```
+
+**Affected**: `model_runner.py`
+
+---
+
+## AC12: Parallel State API Changes
+
+**Versions**: v0.14+
+
+```python
+# v0.13.0
+from vllm.distributed.parallel_state import get_pp_group, get_tp_group, graph_capture
+
+# v0.18+ — new functions
+from vllm.distributed.parallel_state import (
+    get_dcp_group, get_pp_group, get_tp_group,
+    graph_capture, is_global_first_rank,
+    prepare_communication_buffer_for_model,
+)
+```
+
+**Affected**: `worker.py`, `model_runner.py`
+
+---
+
+## AC13: validate_cudagraph_capturing_enabled Renamed
+
+**Versions**: v0.16+
+
+```python
+# v0.13.0
+from vllm.compilation.monitor import validate_cudagraph_capturing_enabled
+
+# v0.18+
+from vllm.compilation.monitor import set_cudagraph_capturing_enabled
+```
+
+**Affected**: `compilation/graph.py`, `model_runner.py`
+
+---
+
+## AC14: AttentionBackend Import Path
+
+**Versions**: v0.14+
+
+```python
+# v0.13.0
+from vllm.attention.backends.abstract import AttentionBackend, AttentionMetadata, AttentionType, MultipleOf
+
+# v0.18+ — check if still same path or moved
+```
+
+**Affected**: `model_runner.py`
+
+---
+
+## AC15: ReconfigureDistributedRequest
+
+**Versions**: v0.16+
+
+```python
+# v0.18+
+from vllm.v1.engine import ReconfigureDistributedRequest, ReconfigureRankType
+```
+
+New distributed reconfiguration API. Plugin worker may need to handle it.
+
+**Affected**: `worker.py`
+
+---
+
+## AC16: EplbState (Expert Load Balancing)
+
+**Versions**: v0.17+
+
+```python
+# v0.18+
+from vllm.distributed.eplb.eplb_state import EplbState
+```
+
+New expert-level load balancing. Plugin model_runner may need to integrate.
+
+**Affected**: `model_runner.py`
+
+---
+
+## AC17: MultiModal API Changes
+
+**Versions**: v0.15+
+
+```python
+# v0.18+
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.encoder_budget import MultiModalBudget
+from vllm.multimodal.inputs import BatchedTensorInputs, MultiModalKwargsItem, PlaceholderRange
+from vllm.multimodal.utils import group_and_batch_mm_kwargs
+```
+
+Significant multimodal API evolution. Plugin model_runner's multimodal handling needs updating.
+
+**Affected**: `model_runner.py`
+
+---
+
+## AC18: LoRA API Changes
+
+**Versions**: v0.15+
+
+```python
+# v0.18+
+from vllm.lora.layers import LoRAMapping, LoRAMappingType
+```
+
+**Affected**: `model_runner.py`
+
+---
+
+## AC19: GPU Worker Submodule Split
+
+**Versions**: v0.17+
+
+In v0.18+, the GPU worker code is split into `vllm/v1/worker/gpu/` subdirectory with many
+submodules (model_runner.py, input_batch.py, buffer_utils.py, etc.). The top-level
+`gpu_model_runner.py` and `gpu_worker.py` may still exist as compatibility shims or may be
+the actual files. Check which is the canonical location.
+
+**Affected**: `worker.py`, `model_runner.py`
+
+---
+
+## Adding New Changes
+
+When a new API incompatibility is discovered during upgrade, append it as AC20, AC21, etc.
+Include:
+- **What** changed (before/after import or signature)
+- **Which versions** introduced the change
+- **Affected** plugin files

--- a/skills/vllm-upgrade-flagos/references/operational-rules.md
+++ b/skills/vllm-upgrade-flagos/references/operational-rules.md
@@ -1,0 +1,151 @@
+# Operational Rules
+
+Rules that apply throughout the entire upgrade process.
+
+## Conda Environments
+
+Two separate conda environments are used:
+
+| Environment | Activate | Contents |
+|---|---|---|
+| `vllm_plugin_update` | `conda activate vllm_plugin_update` | vLLM v0.18.0+ installed (target version) |
+| `vllm_0.13.0_plugin_tree` | `conda activate vllm_0.13.0_plugin_tree` | vLLM v0.13.0 + vllm-plugin-FL installed (current version) |
+
+**Which environment to use when:**
+- **Reading upstream code / git diff**: either environment works (just reading files)
+- **Running plugin tests / import checks**: use `vllm_plugin_update` (the target — plugin must work against new vLLM)
+- **Comparing old behavior**: use `vllm_0.13.0_plugin_tree`
+
+**Activating in bash**: Each bash command runs in a fresh shell, so always activate at the start:
+```bash
+conda activate vllm_plugin_update && python3 -c "import vllm; print(vllm.__version__)"
+```
+
+## Communication Protocol
+
+Actively communicate at every step boundary. Silent execution is unacceptable.
+
+**Status line patterns:**
+- Starting: `🔍 Step N: <what>...`
+- Finding: `📋 Found: <what>`
+- Decision: `✅ Decision: <what and why>`
+- Issue: `⚠️ Issue: <problem>` → `🔧 Fix: <action>`
+- Complete: `✅ Step N complete: <summary>`
+
+**What to report** (concise, at step boundaries only):
+1. Version info — detected current base and target versions (once)
+2. File operations — files created/modified/deleted
+3. Patch summary — list of FL customizations re-applied (batch)
+4. Verification results — pass/fail with key output
+5. Issues — only blocking problems or decisions needing user input
+
+Use AskUserQuestion for ambiguity or choices.
+
+## TaskList Integration
+
+The TaskList is both a progress indicator AND the recovery mechanism after API interruptions.
+
+### On first invocation — create all tasks upfront
+
+After detecting versions, create ALL tasks at once:
+
+```
+Task 1:  Baseline unit tests
+Task 2:  API diff analysis (upstream v0.13.0 → v{{target}})
+Task 3:  Upgrade platform.py
+Task 4:  Upgrade compilation/graph.py
+Task 5:  Upgrade worker/worker.py
+Task 6:  Upgrade worker/model_runner.py
+Task 7:  Upgrade ops layer
+Task 8:  Clean up obsolete models/configs/patches
+Task 9:  Clean up __init__.py registration
+Task 10: Import verification & regression tests
+Task 11: Final report
+```
+
+### Auto-resume protocol
+
+**ALWAYS** start every turn with `TaskList`. Then:
+- `in_progress` tasks exist → continue immediately (do NOT ask user)
+- All `pending`, none `in_progress` → fresh start from first pending
+- All `completed` → output final report
+- User says "continue"/"继续" → resume from first non-completed task
+
+**NEVER ask whether to continue.** After an interruption, just read tasks and keep going.
+
+### Task state discipline
+
+- Mark `in_progress` BEFORE starting work
+- Mark `completed` ONLY after fully done and verified
+- Keep `in_progress` on failure; fix the issue first
+- Task descriptions = single source of truth (enough detail for cold-start)
+
+### Work-until-done principle
+
+Keep working until ALL tasks are completed. Do not stop after one step and wait. Make maximum progress each turn.
+
+## Bash Command Rules
+
+### Timeout management
+
+| Command type | Timeout |
+|---|---|
+| `pytest` (unit tests) | 120s |
+| `python3 -c "import ..."` | 30s |
+| `git diff`, `git log` | 30s |
+| `diff`, `grep`, `find` | 15s |
+| `pip install` | 300s |
+
+### Output management
+
+- Always pipe long output through `tail -N` or `head -N`
+- For pytest: `pytest ... 2>&1 | tail -30`
+- For git diff: `git diff ... | head -200`
+
+### Common failure modes (lessons learned)
+
+1. **Stopping at blocking steps instead of working through them.** If a step requires waiting, use background tasks and continue with independent work.
+2. **Accidentally overwriting vLLM.** Running `pip install -e .` for the plugin can pull vLLM as a dependency. Always use `pip install --no-build-isolation --no-deps -e .` for the plugin.
+3. **If vLLM gets accidentally overwritten**, restore with `MAX_JOBS=96 pip install --no-build-isolation -v -e <vllm_source>`.
+4. **Not verifying imports after each component.** Run `python3 -c "from vllm_fl.xxx import ..."` after each upgrade step.
+
+## Debugging Protocol
+
+### Upstream-first
+
+When a runtime error occurs:
+1. Identify the failing import/call
+2. Check the upstream file at the target version — what's the correct API?
+3. Compare with what the plugin is using
+4. Fix the plugin to match upstream
+
+### CUDA_LAUNCH_BLOCKING
+
+Only use `CUDA_LAUNCH_BLOCKING=1` when:
+- A CUDA kernel crashes with an unhelpful traceback
+- You need to pinpoint the exact failing kernel
+
+Do NOT use for:
+- Import errors or config parsing errors (CPU-side)
+- Normal development/testing
+
+## Resilience
+
+### Auto-resume after interruption
+
+If TaskList shows some tasks `completed` and some not → previous session was interrupted. Do NOT start over. Find first non-completed task, read its description, continue from there. NEVER re-do completed tasks.
+
+## Permission Assumptions
+
+- Full **read/write/execute** for vllm-plugin-FL project directory
+- Full **read** for upstream vLLM source directory
+- No `sudo`/`chmod` needed
+- All fixes stay **inside the plugin directory**
+
+## vLLM Version Protection
+
+**NEVER** modify the installed vLLM version or its source code. Specifically:
+
+1. **Do not change upstream vLLM code** — all customisation goes into the plugin.
+2. **Do not reinstall/upgrade vLLM accidentally** — always use `pip install --no-build-isolation --no-deps -e .` for the plugin.
+3. **If vLLM gets accidentally overwritten**, restore with `MAX_JOBS=96 pip install --no-build-isolation -v -e <vllm_source_dir>`.

--- a/skills/vllm-upgrade-flagos/references/procedure.md
+++ b/skills/vllm-upgrade-flagos/references/procedure.md
@@ -14,6 +14,7 @@ natively supported upstream should be removed from the plugin.
 * Preserve ALL plugin customizations (dispatch, custom ops, platform, IO dumper, FL envs)
 * **Idempotent** — safe to re-run; existing files get overwritten with fresh adaptations
 * Reuse the copy-then-patch pattern from model-migrate-flagos
+* Do NOT replace `current_platform.torch_device_fn.*` calls with `torch.cuda.*`. The plugin supports multiple backends (NVIDIA CUDA, Ascend NPU, MetaX MACA, etc.). `torch_device_fn` is the platform abstraction that routes to the correct device API at runtime. Hardcoding `torch.cuda.*` breaks non-CUDA platforms.
 
 ## Conda Environments
 
@@ -235,9 +236,9 @@ For each:
 - Preserve dispatch integration (`resolve_op` pattern)
 
 Known API migration patterns for ops:
-- `from vllm._custom_ops import silu_and_mul` → removed in v0.18.1. Use `torch.ops._C.silu_and_mul` instead.
-  Other ops (`rms_norm`, `fused_add_rms_norm`, `rotary_embedding`, `moe_sum`, `moe_align_block_size`, `topk_softmax`) still exist in `vllm._custom_ops` as of v0.18.1, but may be removed in future versions. Prefer `torch.ops._C.*` for forward compatibility.
+- `from vllm._custom_ops import <fn>` — some functions removed in v0.18.1 (e.g. `silu_and_mul`). Use `torch.ops._C.<fn>` instead. Check each import against upstream `vllm/_custom_ops.py`.
 - `from vllm.utils.import_utils import init_cached_hf_modules` → removed in v0.18.1. Delete the call entirely.
+- Platform-specific fixes (e.g. CUDA kernel paths) should be marked with inline comments in code, not documented here. Keep this skill platform-agnostic.
 
 ```bash
 conda activate vllm_plugin_update && python3 -c "from vllm_fl.ops import custom_ops; print('ops OK')"

--- a/skills/vllm-upgrade-flagos/references/procedure.md
+++ b/skills/vllm-upgrade-flagos/references/procedure.md
@@ -1,0 +1,438 @@
+# Upgrade Procedure
+
+## Goal
+
+Upgrade vllm-plugin-FL's infrastructure code from its current vLLM base (v0.13.0) to match
+`{{upstream_folder}}` (target: v0.18+). After this upgrade, the plugin's worker, model_runner,
+platform, compilation, and ops layers should be compatible with the new vLLM APIs. Models now
+natively supported upstream should be removed from the plugin.
+
+## Constraints
+
+* Modify **only** `vllm-plugin-FL` (installed with `-e --no-deps`)
+* Do NOT modify the upstream vLLM source or installed vLLM packages
+* Preserve ALL plugin customizations (dispatch, custom ops, platform, IO dumper, FL envs)
+* **Idempotent** — safe to re-run; existing files get overwritten with fresh adaptations
+* Reuse the copy-then-patch pattern from model-migrate-flagos
+
+## Conda Environments
+
+| Environment | Activate | Use for |
+|---|---|---|
+| `vllm_plugin_update` | `conda activate vllm_plugin_update` | Target env — vLLM v0.18.0+ installed. Run all import checks, tests, and verification here. |
+| `vllm_0.13.0_plugin_tree` | `conda activate vllm_0.13.0_plugin_tree` | Old env — vLLM v0.13.0 + current plugin. Use for comparing old behavior or checking old API signatures. |
+
+Each bash command runs in a fresh shell, so always prefix with `conda activate`:
+```bash
+conda activate vllm_plugin_update && <command>
+```
+
+All verification commands in this procedure should run in `vllm_plugin_update` unless stated otherwise.
+
+---
+
+## Plugin Infrastructure Map
+
+| Plugin file | Upstream counterpart | Role |
+|---|---|---|
+| `vllm_fl/worker/worker.py` | `vllm/v1/worker/gpu_worker.py` | GPU worker (init, KV cache, exec loop) |
+| `vllm_fl/worker/model_runner.py` | `vllm/v1/worker/gpu_model_runner.py` | Model runner (loading, forward, sampling) |
+| `vllm_fl/platform.py` | `vllm/platforms/interface.py` + `vllm/platforms/cuda.py` | Platform abstraction |
+| `vllm_fl/compilation/graph.py` | `vllm/compilation/cuda_graph.py` | CUDA graph wrapper |
+| `vllm_fl/ops/fused_moe/layer.py` | `vllm/model_executor/layers/fused_moe/layer.py` | Fused MoE layer |
+| `vllm_fl/ops/fused_moe/fused_moe.py` | `vllm/model_executor/layers/fused_moe/fused_moe.py` | Fused MoE kernel |
+| `vllm_fl/ops/activation.py` | `vllm/model_executor/layers/activation.py` | Activation ops |
+| `vllm_fl/ops/layernorm.py` | `vllm/model_executor/layers/layernorm.py` | LayerNorm ops |
+| `vllm_fl/ops/rotary_embedding.py` | `vllm/model_executor/layers/rotary_embedding.py` | Rotary embedding ops |
+
+---
+
+## Step 1: Baseline Unit Tests
+
+> **→ Tell user**: `🔍 Step 1: Running baseline unit tests before making any changes...`
+
+```bash
+conda activate vllm_plugin_update && pytest {{plugin_folder}}/tests/unit_tests/ -v --tb=short 2>&1 | tail -20
+```
+
+---
+
+## Step 2: API Diff Analysis
+
+> **→ Tell user**: `🔍 Step 2: Analyzing API differences between plugin base (v0.13.0) and upstream...`
+
+For each plugin infrastructure file, compare it against its upstream counterpart.
+
+### 2.1 Measure change scope
+
+For each file pair in the Infrastructure Map:
+
+```bash
+cd {{upstream_folder}}
+git log --oneline v0.13.0..HEAD -- <upstream_file_path> | wc -l
+git diff v0.13.0..HEAD --stat -- <upstream_file_path>
+```
+
+### 2.2 Extract plugin customizations
+
+For each plugin file, identify FL-specific additions that must be preserved:
+
+```bash
+diff {{plugin_folder}}/vllm_fl/worker/worker.py {{upstream_folder}}/vllm/v1/worker/gpu_worker.py | grep "^<" | head -80
+```
+
+Document each customization: which method, what it does, exact code block.
+
+### 2.3 Categorize changes
+
+For each upstream file, categorize into:
+- **Import changes** — new/removed/renamed imports
+- **Method signature changes** — parameters added/removed
+- **New methods/classes** — didn't exist before
+- **Removed methods/classes** — deleted
+- **Structural changes** — class hierarchy, mixin, file splits
+- **Config changes** — new config fields, renamed classes
+
+Cross-reference with `api-changes.md` for known breaking changes.
+
+> **→ Tell user**: Report summary per component (commit count, major API changes).
+
+---
+
+## Step 3: Upgrade platform.py
+
+> **→ Tell user**: `🔧 Step 3: Upgrading platform.py...`
+
+1. Read upstream: `vllm/platforms/interface.py` + `vllm/platforms/cuda.py`
+2. Compare with plugin's `platform.py`:
+   - New abstract methods needing implementation
+   - Renamed methods or changed signatures
+   - New platform capabilities or enums
+3. Update `platform.py`:
+   - Add new required method implementations
+   - Update signatures to match new base class
+   - Preserve FL-specific logic (multi-chip detection, DeviceInfo, etc.)
+4. Verify:
+   ```bash
+   conda activate vllm_plugin_update && python3 -c "from vllm_fl.platform import PlatformFL; print('platform OK')"
+   ```
+
+---
+
+## Step 4: Upgrade compilation/graph.py
+
+> **→ Tell user**: `🔧 Step 4: Upgrading compilation/graph.py...`
+
+1. Read upstream: `vllm/compilation/cuda_graph.py`
+2. Compare: CUDAGraphWrapper, CUDAGraphStat, graph capture API changes
+3. Update: Adapt plugin's GraphWrapper to new upstream APIs, preserve FL customizations
+4. Verify:
+   ```bash
+   conda activate vllm_plugin_update && python3 -c "from vllm_fl.compilation.graph import GraphWrapper; print('compilation OK')"
+   ```
+
+---
+
+## Step 5: Upgrade worker/worker.py
+
+> **→ Tell user**: `🔧 Step 5: Upgrading worker/worker.py...`
+
+### 5.1 Backup and extract customizations
+
+```bash
+cp {{plugin_folder}}/vllm_fl/worker/worker.py {{plugin_folder}}/vllm_fl/worker/worker.py.bak
+```
+
+Extract plugin customizations:
+- FL platform initialization hooks
+- Dispatch system integration (`register_oot_ops`, `managed_inference_mode`)
+- IO dumper integration
+- FL-specific env handling (`fl_envs`)
+- `MemorySnapshot` dataclass (if FL-specific)
+- `get_flag_gems_whitelist_blacklist` calls
+
+### 5.2 Copy-then-patch
+
+1. Copy upstream:
+   ```bash
+   cp {{upstream_folder}}/vllm/v1/worker/gpu_worker.py {{plugin_folder}}/vllm_fl/worker/worker.py
+   ```
+2. Add header: `# Adapted from vllm/v1/worker/gpu_worker.py @ v{{target_version}}`
+3. Apply patches:
+   - Add FL-specific imports
+   - Re-apply all FL customizations from 5.1
+   - Ensure `register_oot_ops` called at the right point
+   - Preserve `managed_inference_mode` integration
+4. Verify:
+   ```bash
+   conda activate vllm_plugin_update && python3 -c "from vllm_fl.worker.worker import Worker; print('worker OK')"
+   ```
+
+---
+
+## Step 6: Upgrade worker/model_runner.py
+
+> **→ Tell user**: `🔧 Step 6: Upgrading worker/model_runner.py — the largest component...`
+
+### 6.1 Backup and catalog customizations
+
+```bash
+cp {{plugin_folder}}/vllm_fl/worker/model_runner.py {{plugin_folder}}/vllm_fl/worker/model_runner.py.bak
+```
+
+Catalog ALL plugin customizations:
+- `managed_inference_mode` context manager usage
+- IO dumper hooks
+- Dispatch integration (`resolve_op`, `get_flag_gems_whitelist_blacklist`)
+- Custom CUDA graph wrapper (`GraphWrapper` instead of `CUDAGraphWrapper`)
+- FL envs (`fl_envs`)
+- Custom op registration (`register_oot_ops`)
+- FlagGems-specific attention backend selection
+- Custom warmup logic
+- FL-specific forward context modifications
+
+Document each: which method, what it does, exact code block.
+
+### 6.2 Copy-then-patch
+
+1. Copy upstream:
+   ```bash
+   cp {{upstream_folder}}/vllm/v1/worker/gpu_model_runner.py {{plugin_folder}}/vllm_fl/worker/model_runner.py
+   ```
+2. Add header noting upstream version
+3. Apply import patches:
+   - Add FL-specific imports
+   - Replace `CUDAGraphWrapper` with `GraphWrapper`
+   - Handle moved imports (check `api-changes.md`)
+4. Re-apply each plugin customization from catalog
+5. Handle new upstream features:
+   - New methods plugin doesn't customize → leave as-is
+   - New methods interacting with customized code → adapt
+   - Removed methods plugin was overriding → remove override
+6. Verify:
+   ```bash
+   conda activate vllm_plugin_update && python3 -c "from vllm_fl.worker.model_runner import GPUModelRunner; print('model_runner OK')"
+   ```
+
+---
+
+## Step 7: Upgrade ops layer
+
+> **→ Tell user**: `🔧 Step 7: Checking ops layer compatibility...`
+
+For each op file, compare plugin wrapper with upstream interface:
+
+1. `fused_moe/layer.py` — FusedMoE class interface
+2. `fused_moe/fused_moe.py` — kernel function signatures
+3. `activation.py` — activation op signatures
+4. `layernorm.py` — layernorm op signatures
+5. `rotary_embedding.py` — rotary embedding signatures
+6. `custom_ops.py` — OOT op registration
+
+For each:
+- If upstream interface changed → update plugin wrapper
+- If new ops added upstream → check if dispatch needs updating
+- Preserve dispatch integration (`resolve_op` pattern)
+
+Known API migration patterns for ops:
+- `from vllm._custom_ops import silu_and_mul` → removed in v0.18.1. Use `torch.ops._C.silu_and_mul` instead.
+  Other ops (`rms_norm`, `fused_add_rms_norm`, `rotary_embedding`, `moe_sum`, `moe_align_block_size`, `topk_softmax`) still exist in `vllm._custom_ops` as of v0.18.1, but may be removed in future versions. Prefer `torch.ops._C.*` for forward compatibility.
+- `from vllm.utils.import_utils import init_cached_hf_modules` → removed in v0.18.1. Delete the call entirely.
+
+```bash
+conda activate vllm_plugin_update && python3 -c "from vllm_fl.ops import custom_ops; print('ops OK')"
+```
+
+---
+
+## Step 8: Clean dead code (models, configs, patches)
+
+> **→ Tell user**: `🔧 Step 8: Identifying and removing dead model/config/patch code...`
+
+After upgrading, many models/configs/patches may now be natively supported upstream.
+Do NOT blindly delete everything — some configs or patches may still be needed if they
+haven't been upstreamed yet.
+
+### 8.1 Identify dead model files
+
+For each `.py` file in `{{plugin_folder}}/vllm_fl/models/` (excluding `__init__.py`):
+
+1. Check if the model class exists in upstream `{{upstream_folder}}/vllm/model_executor/models/`
+2. Check if the model class is registered in upstream's `registry.py`
+3. Check if the FL model is still registered in `{{plugin_folder}}/vllm_fl/__init__.py` `register_model()`
+4. If the model exists upstream AND is not registered by the plugin → it's dead code, delete it
+
+### 8.2 Identify dead config files
+
+For each `.py` file in `{{plugin_folder}}/vllm_fl/configs/` (excluding `__init__.py`):
+
+1. Check if the config's `model_type` exists in upstream's `_CONFIG_REGISTRY` in
+   `{{upstream_folder}}/vllm/transformers_utils/config.py`
+2. Check if the config is still imported/used by any remaining plugin code
+3. If the config exists upstream AND is not imported by remaining plugin code → delete it
+
+### 8.3 Identify dead patch files
+
+For each `.py` file in `{{plugin_folder}}/vllm_fl/patches/` (excluding `__init__.py`):
+
+1. Check if the patches fix issues that are already resolved in the target upstream version
+2. Check if the patches are still imported/called from `__init__.py` or other plugin code
+3. Only delete patches that are confirmed no longer needed
+
+### 8.4 Verify no dangling imports
+
+```bash
+conda activate vllm_plugin_update && grep -rn 'from vllm_fl\.models\.\|from vllm_fl\.configs\.\|from vllm_fl\.patches\.' \
+  {{plugin_folder}}/vllm_fl/ --include='*.py' | grep -v __pycache__
+```
+
+Any remaining imports of deleted files must be removed.
+
+> **→ Tell user**: Report which files were deleted and which were kept (with reasons).
+
+---
+
+## Step 9: Clean up __init__.py
+
+> **→ Tell user**: `🔧 Step 9: Cleaning up __init__.py...`
+
+1. In `register_model()`: remove registration code for models/configs that are now upstream
+2. Keep `register_model()` if it still registers anything not yet upstream (e.g. custom configs)
+3. If `register_model()` is completely empty after cleanup, delete the function entirely
+4. In `register()`: remove patch imports/calls for patches that were deleted in Step 8
+5. Remove `_patch_transformers_compat()` only if no remaining patches or models need it
+6. Keep `register()` function — platform registration is still needed
+7. Verify:
+   ```bash
+   conda activate vllm_plugin_update && python3 -c "import vllm_fl; print('init OK')"
+   ```
+
+---
+
+## Step 10: Import Verification & Regression Tests
+
+> **→ Tell user**: `🔍 Step 10: Running full verification...`
+
+### 10.1 Import verification
+
+```bash
+conda activate vllm_plugin_update && python3 -c "
+import vllm_fl
+print('vllm_fl OK')
+from vllm_fl.platform import PlatformFL
+print('platform OK')
+from vllm_fl.compilation.graph import GraphWrapper
+print('compilation OK')
+from vllm_fl.worker.worker import Worker
+print('worker OK')
+from vllm_fl.worker.model_runner import GPUModelRunner
+print('model_runner OK')
+from vllm_fl.ops.custom_ops import register_oot_ops
+print('ops OK')
+print('All imports passed!')
+"
+```
+
+### 10.2 Offline inference end-to-end test
+
+This is the **primary verification gate**. The upgrade is considered successful only when this
+command completes without error:
+
+```bash
+conda activate vllm_plugin_update && python {{plugin_folder}}/examples/qwen3_5_offline_inference.py
+```
+
+This script exercises the full plugin stack (platform → worker → model_runner → ops → dispatch)
+with a real model inference. If it runs to completion and produces output, the upgrade is verified.
+
+If it fails, debug the traceback — it will point to the exact plugin component that still has
+incompatibilities with the new vLLM version.
+
+### 10.3 Regression unit tests
+
+```bash
+conda activate vllm_plugin_update && pytest {{plugin_folder}}/tests/unit_tests/ -v --tb=short 2>&1 | tail -30
+```
+
+Compare with Step 1 baseline. Fix new failures.
+
+### 10.4 Functional tests
+
+```bash
+conda activate vllm_plugin_update && pytest {{plugin_folder}}/tests/functional_tests/ -v --tb=short 2>&1 | tail -30
+```
+
+### 10.5 Performance benchmark
+
+Run the throughput benchmark to establish a post-upgrade performance baseline. Compare with
+pre-upgrade numbers (if available) to detect performance regressions.
+
+```bash
+conda activate vllm_plugin_update && bash {{plugin_folder_relative_to_skill}}/scripts/benchmark.sh <MODEL_DISPLAY_NAME>
+```
+
+For example, with Qwen3.5-397B:
+
+```bash
+conda activate vllm_plugin_update && bash scripts/benchmark.sh Qwen3.5-397B-A17B-Real
+```
+
+The script runs `vllm bench throughput` with:
+- 100 prompts, input_len=6144, output_len=1024
+- TP=4, gpu_memory_utilization=0.9, dummy weights
+
+Key metrics to check:
+- **Throughput** (tokens/s): should not regress significantly vs pre-upgrade
+- **TTFT** (time to first token): latency should remain comparable
+- **No OOM or CUDA errors**: confirms memory management is correct after upgrade
+
+> **→ Tell user**: Report throughput numbers and comparison with pre-upgrade baseline (if available).
+
+---
+
+## Step 11: Update Version References
+
+> **→ Tell user**: `🔧 Step 11: Updating version references...`
+
+1. Update header comments in worker.py and model_runner.py to reference new base version
+2. Update `pyproject.toml` vLLM version pin if needed
+3. Update `vllm_fl/version.py` if needed
+
+---
+
+## Final Report
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📊 Plugin Upgrade Complete: vLLM v0.13.0 → v{{target_version}}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Infrastructure upgraded:
+  - vllm_fl/platform.py
+  - vllm_fl/compilation/graph.py
+  - vllm_fl/worker/worker.py
+  - vllm_fl/worker/model_runner.py
+  - vllm_fl/ops/...
+  - vllm_fl/__init__.py
+
+Models deleted (now upstream):
+  - models/, configs/, patches/ — all cleared
+
+Plugin customizations preserved:
+  - dispatch, custom ops, platform, compilation, IO dumper, FL envs
+
+Verification:
+  - Offline inference (qwen3_5_offline_inference.py): PASS / FAIL
+  - Unit (baseline):    N passed, M failed, K skipped
+  - Unit (regression):  N passed, M failed, K skipped
+  - Functional:         N passed, M failed, K skipped
+
+Performance benchmark:
+  - Model: <MODEL_DISPLAY_NAME>
+  - Throughput: X.XX tokens/s (pre-upgrade: Y.YY tokens/s)
+  - Regression: +/-Z.Z%
+
+Known issues / TODOs:
+  - [list or "None"]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/skills/vllm-upgrade-flagos/scripts/benchmark.sh
+++ b/skills/vllm-upgrade-flagos/scripts/benchmark.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Step 10: Benchmark verification
+# Usage: bash scripts/benchmark.sh <MODEL_DISPLAY_NAME>
+set -euo pipefail
+
+MODEL="${1:?Usage: benchmark.sh <MODEL_DISPLAY_NAME>}"
+
+export USE_FLAGGEMS=0
+vllm bench throughput \
+    --model "/models/${MODEL}" \
+    --dataset-name random \
+    --input-len 6144 \
+    --output-len 1024 \
+    --num-prompts 100 \
+    --tensor-parallel-size 4 \
+    --gpu-memory-utilization 0.9 \
+    --load-format dummy \
+    --trust-remote-code


### PR DESCRIPTION
Add a performance benchmark step to the vllm-upgrade-flagos skill's upgrade procedure and document API migration patterns discovered during the vLLM v0.18.1 upgrade.                                                                                                   
