### PR TITLE
feat(kernelgen-flagos): centralize MCP setup into dedicated sub-skill

### DIFF
--- a/skills/kernelgen-flagos/SKILL.md
+++ b/skills/kernelgen-flagos/SKILL.md
@@ -46,6 +46,8 @@ This is a **unified entry point** that bundles generation and optimization sub-s
 | **Platform Specialization** | |
 | `kernelgen-specialize.md` | Specialize Triton operators to target platforms (e.g., GPU → Ascend NPU) via MCP `specialize_kernel` |
 | `kernelgen-specialize-for-flaggems.md` | Platform specialization + **FlagGems** integration (4 modes: vendor-ops/vendor-fused/override-builtin/experimental) |
+| **MCP Configuration** | |
+| `kernelgen-mcp-setup.md` | Check and auto-configure the `kernelgen-server` MCP service (URL built-in, user only provides Token) |
 | **Feedback** | |
 | `kernelgen-submit-feedback.md` | Submit bug reports and feedback via GitHub or email |
 
@@ -54,6 +56,23 @@ All sub-skill files are located in the **same directory** as this `SKILL.md` fil
 ---
 
 ## Routing Protocol — Follow This BEFORE Doing Anything Else
+
+### Phase 0: MCP Configuration Check
+
+Before anything else, ensure the `kernelgen-server` MCP service is configured and ready.
+
+Use the Glob tool to find `kernelgen-mcp-setup.md` in this skill's directory:
+
+```
+Glob: **/skills/kernelgen-flagos/kernelgen-mcp-setup.md
+```
+
+Then use the Read tool to read the matched file and **follow its instructions exactly**.
+
+- If MCP is already configured → proceed to Phase 1.
+- If MCP is not configured → the setup skill will guide the user through configuration.
+  Once configuration is written and the user is prompted to restart, **stop here** — do not
+  continue to Phase 1.
 
 ### Phase 1: Detect Repository Type
 

--- a/skills/kernelgen-flagos/kernelgen-generate-for-flaggems.md
+++ b/skills/kernelgen-flagos/kernelgen-generate-for-flaggems.md
@@ -11,9 +11,8 @@ You are an expert at generating GPU kernel operators for the FlagGems project us
 - **Glob**: find files by pattern
 - **MCP tools**: `mcp__kernelgen-mcp__generate_kernel` and `mcp__kernelgen-mcp__optimize_kernel`
 
-> **MCP Prerequisite Check**: If the user has not configured the kernelgen MCP service (i.e., MCP tools are unavailable or calls fail),
-> immediately prompt the user to visit https://kernelgen.flagos.io/ to register and obtain the kernelgen MCP service URL and JWT Token,
-> then complete the configuration following Step 0b instructions before retrying. Do not proceed with subsequent steps if MCP is not ready.
+> **⚠️ MCP Prerequisite**: MCP configuration is handled by `SKILL.md` Phase 0. If MCP tools fail during execution,
+> stop and tell the user to visit https://kernelgen.flagos.io/mcp 获取 Token 后重新配置。
 
 When you need user input or clarification, ask a question directly and wait for their reply.
 Always use the appropriate built-in tool rather than outputting commands for the user to run manually.
@@ -147,37 +146,10 @@ After installing, re-run the diagnostic via the shell tool to confirm everything
 
 ### 0b. Check MCP Availability
 
-Verify that the `kernelgen-mcp` MCP server is configured and reachable.
-
-Use the Read tool to read `.claude/settings.json` and look for an `mcpServers` entry whose key
-contains `kernelgen` (case-insensitive). If the file does not exist, treat it as "MCP not configured".
-
-**If the MCP server is NOT configured**, stop and print the following message to the user, then
-wait for the user to provide the URL and JWT token:
-
-```
-The kernelgen-mcp service is not yet configured. Please follow these steps:
-
-1. Visit https://kernelgen.flagos.io/ to register and obtain a JWT Token.
-2. Add the following MCP configuration to `.claude/settings.json` (replace <YOUR_URL> and <YOUR_JWT_TOKEN> with actual values):
-
-{
-  "mcpServers": {
-    "kernelgen-mcp": {
-      "type": "sse",
-      "url": "<YOUR_URL>",
-      "headers": {
-        "Authorization": "Bearer <YOUR_JWT_TOKEN>"
-      }
-    }
-  }
-}
-
-3. After configuration is complete, please re-run this command.
-```
-
-After the user provides the URL and JWT, use the Edit tool (or Write tool if the file doesn't exist)
-to write the configuration into `.claude/settings.json`, merging with any existing content. Then proceed.
+> **MCP configuration is handled centrally by `SKILL.md` Phase 0 (via `kernelgen-mcp-setup.md`).**
+> By the time execution reaches this sub-skill, MCP should already be configured and ready.
+> If MCP tools are unavailable or calls fail at any point, stop and tell the user:
+> "MCP 服务不可用，请检查配置或访问 https://kernelgen.flagos.io/mcp 获取 Token 后重新配置。"
 
 **If the MCP server IS configured**, proceed to Step 1.
 

--- a/skills/kernelgen-flagos/kernelgen-generate-for-vllm.md
+++ b/skills/kernelgen-flagos/kernelgen-generate-for-vllm.md
@@ -3,9 +3,8 @@
 
 You are an expert at generating GPU kernel operators for the vLLM project using the `kernelgen-mcp` MCP service.
 
-> **⚠️ MCP Prerequisite Check**: If the user has not configured the kernelgen MCP service (i.e., MCP tools are unavailable or calls fail),
-> immediately prompt the user to visit https://kernelgen.flagos.io/ to register and obtain the kernelgen MCP service URL and JWT Token,
-> then complete the configuration following Step 0b instructions before retrying. Do not proceed with subsequent steps if MCP is not ready.
+> **⚠️ MCP Prerequisite**: MCP configuration is handled by `SKILL.md` Phase 0. If MCP tools fail during execution,
+> stop and tell the user to visit https://kernelgen.flagos.io/mcp 获取 Token 后重新配置。
 
 ## Execution Rules
 
@@ -112,56 +111,10 @@ all imports succeed.
 
 ### 0b. Check MCP Availability
 
-Use the Read tool to read the file `.claude/settings.json` at the project root.
-If the file does not exist, the MCP is NOT configured.
-
-If the file exists, parse the JSON and check whether the exact key `"kernelgen-mcp"` exists
-under `mcpServers`:
-
-```
-mcpServers["kernelgen-mcp"]
-```
-
-- If the key `"kernelgen-mcp"` does **not** exist → the MCP is NOT configured.
-- If the key `"kernelgen-mcp"` **does** exist → the MCP IS configured — proceed to Step 1.
-
-Do NOT use substring matching (e.g., matching `"kernelgen"` inside `"my_kernelgen_server"`).
-Only the exact key `"kernelgen-mcp"` counts.
-
-**If the MCP server is NOT configured**, stop and tell the user:
-
-```
-kernelgen-mcp service is not configured. Please follow these steps:
-
-1. Visit https://kernelgen.flagos.io/ to register and obtain your JWT Token.
-2. Provide your MCP service URL and JWT Token to me, and I will help you write the configuration.
-
-   The final configuration format is as follows:
-   {
-     "mcpServers": {
-       "kernelgen-mcp": {
-         "type": "sse",
-         "url": "<YOUR_URL>",
-         "headers": {
-           "Authorization": "Bearer <YOUR_JWT_TOKEN>"
-         }
-       }
-     }
-   }
-```
-
-Wait for the user to provide the URL and JWT Token. Then:
-
-1. Use the Read tool to check if `.claude/settings.json` already exists.
-2. If it exists, read its content and parse the JSON. Then:
-   - If `mcpServers` key already exists, add `"kernelgen-mcp": {...}` into it **without
-     removing any other existing MCP server entries**.
-   - If `mcpServers` key does not exist, create it with the single `kernelgen-mcp` entry.
-   - **Never overwrite the entire file** — preserve all other top-level keys.
-3. If the file does not exist, create it with just the `mcpServers` object.
-4. Use the Write tool (for new file) or Edit tool (for existing file) to save.
-5. Tell the user to **restart Claude Code** so the new MCP server is picked up, then re-run
-   the `/kernelgen_for_vllm` command.
+> **MCP configuration is handled centrally by `SKILL.md` Phase 0 (via `kernelgen-mcp-setup.md`).**
+> By the time execution reaches this sub-skill, MCP should already be configured and ready.
+> If MCP tools are unavailable or calls fail at any point, stop and tell the user:
+> "MCP 服务不可用，请检查配置或访问 https://kernelgen.flagos.io/mcp 获取 Token 后重新配置。"
 
 **If the MCP server IS configured**, proceed to Step 1.
 

--- a/skills/kernelgen-flagos/kernelgen-generate.md
+++ b/skills/kernelgen-flagos/kernelgen-generate.md
@@ -14,9 +14,8 @@ placing code.
 - **Glob**: find files by pattern
 - **MCP tools**: `mcp__kernelgen-mcp__generate_kernel` and `mcp__kernelgen-mcp__optimize_kernel`
 
-> **⚠️ MCP Prerequisite Check**: If the user has not configured the kernelgen MCP service (i.e., the MCP tools are unavailable or calls fail),
-> immediately prompt the user to visit https://kernelgen.flagos.io/ to register and obtain the kernelgen MCP service URL and JWT Token,
-> then follow the instructions in Step 0b to complete the configuration and retry. Do not proceed with subsequent steps if MCP is not ready.
+> **⚠️ MCP Prerequisite**: MCP configuration is handled by `SKILL.md` Phase 0. If MCP tools fail during execution,
+> stop and tell the user to visit https://kernelgen.flagos.io/mcp 获取 Token 后重新配置。
 
 ## Execution Rules
 
@@ -107,45 +106,10 @@ torch and triton imports succeed.
 
 ### 0b. Check MCP Availability
 
-Use the Read tool to check for MCP configuration. **Only check project-local paths** — do NOT
-attempt to read user home directory (`~/`) as Claude Code typically cannot access it:
-
-1. `.claude/settings.json` — look for `mcpServers` containing the key `"kernelgen-mcp"`
-2. `.mcp.json` — same check
-
-If found, check whether the exact key `"kernelgen-mcp"` exists under `mcpServers`.
-Do NOT use substring matching (e.g., matching `"kernelgen"` inside another key name).
-
-**If the MCP server is NOT found in either file**, ask the user:
-
-```
-kernelgen-mcp service was not detected in the project configuration.
-
-Possible scenarios:
-  A) Not yet configured — Please visit https://kernelgen.flagos.io/ to register and obtain a JWT Token,
-     then provide me with the URL and Token, and I will write them to .claude/settings.json.
-  B) Already configured globally — If you have already configured kernelgen-mcp in your global settings,
-     please let me know and I will skip this step and continue.
-
-The final configuration format is as follows (.claude/settings.json):
-{
-  "mcpServers": {
-    "kernelgen-mcp": {
-      "type": "sse",
-      "url": "<YOUR_URL>",
-      "headers": {
-        "Authorization": "Bearer <YOUR_JWT_TOKEN>"
-      }
-    }
-  }
-}
-```
-
-Wait for the user to respond. Then:
-- If the user provides URL + JWT: use the Edit tool (or Write tool if the file doesn't exist)
-  to write the configuration, **merging** with any existing content (never overwrite other MCP
-  server entries or top-level keys). Tell the user to restart Claude Code.
-- If the user says MCP is configured globally: proceed to Step 1.
+> **MCP configuration is handled centrally by `SKILL.md` Phase 0 (via `kernelgen-mcp-setup.md`).**
+> By the time execution reaches this sub-skill, MCP should already be configured and ready.
+> If MCP tools are unavailable or calls fail at any point, stop and tell the user:
+> "MCP 服务不可用，请检查配置或访问 https://kernelgen.flagos.io/mcp 获取 Token 后重新配置。"
 
 **If the MCP server IS configured**, proceed to Step 1.
 

--- a/skills/kernelgen-flagos/kernelgen-mcp-setup.md
+++ b/skills/kernelgen-flagos/kernelgen-mcp-setup.md
@@ -1,0 +1,91 @@
+# KernelGen MCP Configuration Check & Auto-Setup
+
+This file is responsible for checking whether the `kernelgen-mcp` MCP service is configured,
+and guiding the user through automatic configuration if it is not.
+Before any sub-skill (generate / optimize / specialize) executes, `SKILL.md` dispatches to
+this file to ensure MCP is ready before proceeding to subsequent workflows.
+
+---
+
+## Step 1: Check Whether MCP Is Already Configured
+
+Use the Read tool to check the following files in order (only check project-local paths — do not read the user's home directory):
+
+1. `.mcp.json`
+2. `.claude/settings.json`
+
+For each file:
+- If the file does not exist, skip it
+- If the file exists, parse the JSON and check whether `mcpServers` contains a key that includes `kernelgen` (case-insensitive)
+
+**Decision rules**:
+- Found in any file → **MCP is configured**, return immediately and continue the workflow
+- Not found in either file → **MCP is not configured**, proceed to Step 2
+
+---
+
+## Step 2: Guide the User to Obtain a Token
+
+Output the following message to the user:
+
+```
+The KernelGen MCP toolset is not yet configured.
+
+Please follow these steps:
+1. Visit https://kernelgen.flagos.io/mcp to register and obtain your KernelGen Token
+2. Paste the KernelGen Token here, and I will complete the configuration automatically
+
+(You only need to provide the KernelGen Token — the MCP service URL is built-in and does not need to be entered separately)
+```
+
+Wait for the user to provide the Token.
+
+---
+
+## Step 3: Auto-Write Configuration
+
+After the user provides the Token, write the configuration using the following logic:
+
+**Target configuration format** (written to `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "kernelgen-server": {
+      "type": "sse",
+      "url": "https://kernelgen.flagos.io/sse/",
+      "headers": {
+        "Authorization": "Bearer <USER_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+**Write logic**:
+
+1. Use the Read tool to check whether `.mcp.json` already exists
+2. **If the file already exists**:
+   - Read and parse the JSON
+   - If the `mcpServers` key already exists, merge `"kernelgen-server": {...}` into it — **do not delete any other existing MCP service entries**
+   - If the `mcpServers` key does not exist, create it and add the `kernelgen-server` entry
+   - Use the Edit tool to update the file
+3. **If the file does not exist**:
+   - Use the Write tool to create the file with the complete JSON above
+
+**Important notes**:
+- The MCP service URL is fixed as `https://kernelgen.flagos.io/sse/` — the user does not need to provide it
+- The key name uses `kernelgen-server` (consistent with the MCP tool names `mcp__kernelgen-server__*`)
+- Never overwrite other configuration entries in the file
+
+---
+
+## Step 4: Prompt the User to Restart
+
+After the configuration is written, output the following to the user:
+
+```
+MCP configuration has been written to .mcp.json. Please restart Claude Code for the configuration to take effect, then re-run the command.
+```
+
+**Stop here** — do not continue executing subsequent sub-skill workflows. When the user restarts and re-triggers the skill, Step 1 will detect that the configuration already exists and pass through directly.


### PR DESCRIPTION
## Summary

Extract duplicated MCP configuration logic from 3 generate sub-skills into a dedicated `kernelgen-mcp-setup.md`, and add Phase 0 routing in `SKILL.md` for unified dispatch.

## Changes

- Add `kernelgen-mcp-setup.md`: unified MCP configuration check & auto-setup workflow (check `.mcp.json` / `.claude/settings.json`, guide user to obtain Token, auto-write config)
- `SKILL.md`: add Phase 0 (MCP Configuration Check) to the routing protocol, executed before Phase 1 (repo detection)
- `kernelgen-generate.md`, `kernelgen-generate-for-flaggems.md`, `kernelgen-generate-for-vllm.md`: remove per-file MCP setup logic, defer to Phase 0 via `kernelgen-mcp-setup.md`

## Motivation

Previously each generate sub-skill had its own MCP configuration check with slightly different instructions and formats. This caused maintenance burden and inconsistent user experience. Now all MCP setup is handled in one place before any sub-skill executes.