### PR TITLE
fix: update MCP URL from http to https in README

### DIFF
--- a/skills/kernelgen-flagos/README.md
+++ b/skills/kernelgen-flagos/README.md
@@ -26,9 +26,9 @@ Perform all of the following steps except for obtaining the KernelGen Token in y
 
 2. In your agent client, send a prompt to connect to the KernelGen Operator Development MCP Toolkit, for example:
 
-   * "Connect to MCP, its URL is `http://kernelgen.flagos.io/sse` and token is `<your KernelGen Token>`."
+   * "Connect to MCP, its URL is `https://kernelgen.flagos.io/sse` and token is `<your KernelGen Token>`."
 
-   * "Please configure the kernelgen MCP with the URL `http://kernelgen.flagos.io/sse` and the token is `<your KernelGen Token>`. "
+   * "Please configure the kernelgen MCP with the URL `https://kernelgen.flagos.io/sse` and the token is `<your KernelGen Token>`. "
 
    **Note**: You may need to restart your agent to let the settings take effect. Check this in the documentation of the relevant AI agent.
 

--- a/skills/kernelgen-flagos/README_zh.md
+++ b/skills/kernelgen-flagos/README_zh.md
@@ -26,9 +26,9 @@ KernelGen `kernelgen-flagos` 技能（Skills）是 FlagOS 推出的统一 AI 编
 
 2. 在您的 AI 智能体客户端中，发送提示词以连接 KernelGen 算子开发 MCP 工具集，例如：
 
-   * "连接 MCP，其 URL 为 `http://kernelgen.flagos.io/sse`，token 为 `<your KernelGen Token>`。"
+   * "连接 MCP，其 URL 为 `https://kernelgen.flagos.io/sse`，token 为 `<your KernelGen Token>`。"
 
-   * "请配置 kernelgen MCP，URL 为 `http://kernelgen.flagos.io/sse`，token 为 `<your KernelGen Token>`。"
+   * "请配置 kernelgen MCP，URL 为 `https://kernelgen.flagos.io/sse`，token 为 `<your KernelGen Token>`。"
 
    **注意**：您可能需要重启 AI 智能体以使设置生效。请参阅相关 AI 智能体的文档进行确认。
 


### PR DESCRIPTION
Update the MCP connection URL from `http://kernelgen.flagos.io/sse` to `https://kernelgen.flagos.io/sse` in both README.md and README_zh.md.